### PR TITLE
Uncomment bulma to prevent broken styles.

### DIFF
--- a/templates/base/_base.html
+++ b/templates/base/_base.html
@@ -15,8 +15,8 @@
     <meta property="og:type" content="website">
 
     <!-- Bulma CSS -->
-    <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/1.0.3/css/bulma.min.css">
-    <link rel="stylesheet" href="{% static 'css/styles.css' %}"> -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/1.0.3/css/bulma.min.css">
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
 
     <!-- Tailwind -->
     <link href="{% static 'css/styles.css' %}" rel="stylesheet">


### PR DESCRIPTION
Keep bulma uncommented in base.html to prevent broken styles on pages not yet updated with tailwind.