### PR TITLE
Store phone numbers as E.164 in every environment

### DIFF
--- a/config/base_settings.py
+++ b/config/base_settings.py
@@ -440,3 +440,18 @@ MAINTENANCE_MODE_IGNORE_IP_ADDRESSES = [
 # Google reCAPTCHA v2
 RECAPTCHA_PUBLIC_KEY = config('RECAPTCHA_PUBLIC_KEY')
 RECAPTCHA_PRIVATE_KEY = config('RECAPTCHA_PRIVATE_KEY')
+
+# Phone numbers
+#
+# These belong here rather than in a per-environment file. They were previously
+# set in local_settings only, so dev and production ran with no default region:
+# `PhoneNumberField.get_prep_value` had nothing to parse a bare national number
+# like "0851639462" against, and silently stored the raw string instead of a
+# valid number. Roughly 4,600 guardian numbers ended up unreadable that way and
+# had to be repaired by `manage.py normalise_phone_numbers`.
+#
+# Every number is Irish, so IE is the region to fall back on when one is written
+# without a country code. Storing E.164 keeps the value unambiguous even if the
+# region is ever wrong or missing.
+PHONENUMBER_DEFAULT_REGION = 'IE'
+PHONENUMBER_DB_FORMAT = 'E164'

--- a/users/management/commands/normalise_phone_numbers.py
+++ b/users/management/commands/normalise_phone_numbers.py
@@ -1,0 +1,203 @@
+"""
+One-off repair of the legacy phone numbers on the User model.
+
+Background
+----------
+`sync_users_from_remote` mapped the WordPress `billing_phone` meta key to
+`other_phone`, so users imported from the old site have a blank `mobile_phone`
+even though we hold a perfectly good number for them. Everything that reads a
+guardian's phone (admin lists, class lists, school exports) looks at
+`mobile_phone` only, so those numbers are invisible.
+
+The numbers were also stored in whatever shape WordPress happened to hold them
+("0851639462", "085 163 9462", "00353 85..."). `PHONENUMBER_DEFAULT_REGION` is
+only set in local_settings, so on dev and production a bare national number has
+no region to be parsed against and `PhoneNumberField.get_prep_value` falls back
+to storing the raw string unchanged. That affects the numbers already sitting in
+`mobile_phone` as well as the ones stranded in `other_phone`.
+
+The command makes two passes:
+
+  1. backfill  - users with a blank `mobile_phone` and a usable `other_phone`
+                 get that number copied across, normalised.
+  2. normalise - users who already have a `mobile_phone` keep it, but it is
+                 rewritten in a consistent format.
+
+An existing `mobile_phone` is never replaced by the `other_phone` value, and
+`other_phone` itself is never modified or cleared -- it stays as the original
+record of what was imported.
+
+Every number written is valid E.164 (+353...). The command writes through
+`Value(..., output_field=CharField())` rather than assigning to the field,
+because `PhoneNumberField.get_prep_value` reformats using
+`PHONENUMBER_DB_FORMAT` -- which is 'NATIONAL' in local_settings and unset (so
+E.164) everywhere else. Going through the plain CharField keeps the result
+identical in every environment instead of re-creating the original bug locally.
+
+Numbers that cannot be parsed as a valid number are left exactly as they are and
+listed in the report so they can be chased manually.
+
+Usage
+-----
+    python manage.py normalise_phone_numbers                     # dry run, both passes
+    python manage.py normalise_phone_numbers --commit
+    python manage.py normalise_phone_numbers --report skipped.csv
+"""
+
+import csv
+import re
+
+import phonenumbers
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Case, CharField, Q, Value, When
+
+from users.models import User
+
+BATCH_SIZE = 500
+
+# Keep digits and a leading '+'; drop spaces, brackets, dashes and stray text.
+_NON_DIALLABLE = re.compile(r"[^0-9+]")
+
+
+def normalise_irish(raw):
+    """Return a raw phone string as valid E.164, or None if it isn't one.
+
+    Numbers are assumed to be Irish, so bare national numbers are parsed against
+    region IE. A number that already carries its own country code (+44...) keeps
+    it -- the region only applies when there is nothing else to go on.
+    """
+    digits = _NON_DIALLABLE.sub("", raw or "")
+    if not digits:
+        return None
+
+    # International prefix dialled the old way: 00353... -> +353...
+    if digits.startswith("00"):
+        digits = "+" + digits[2:]
+    # Country code present but unmarked: 353... -> +353...
+    elif digits.startswith("353"):
+        digits = "+" + digits
+    # Country code followed by the national trunk '0': +3530xx -> +353xx
+    if digits.startswith("+3530"):
+        digits = "+353" + digits[5:]
+
+    try:
+        number = phonenumbers.parse(digits, "IE")
+    except phonenumbers.NumberParseException:
+        return None
+
+    if not phonenumbers.is_valid_number(number):
+        return None
+
+    return phonenumbers.format_number(number, phonenumbers.PhoneNumberFormat.E164)
+
+
+class Command(BaseCommand):
+    help = "Recover legacy phone numbers into mobile_phone and store them as E.164."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--commit",
+            action="store_true",
+            help="Write the changes. Without this the command only reports.",
+        )
+        parser.add_argument(
+            "--report",
+            metavar="PATH",
+            help="Write the numbers that could not be parsed to this CSV.",
+        )
+
+    def handle(self, *args, **options):
+        commit = options["commit"]
+
+        backfill, backfill_skipped = self._collect_backfill()
+        normalise, normalise_skipped = self._collect_normalise()
+
+        self.stdout.write(self.style.MIGRATE_HEADING("Pass 1 — backfill from other_phone"))
+        self.stdout.write(f"  blank mobile_phone with an other_phone : {len(backfill) + len(backfill_skipped)}")
+        self.stdout.write(self.style.SUCCESS(f"  recoverable                           : {len(backfill)}"))
+        self.stdout.write(self.style.WARNING(f"  unparseable, left alone               : {len(backfill_skipped)}"))
+
+        self.stdout.write(self.style.MIGRATE_HEADING("Pass 2 — reformat existing mobile_phone"))
+        self.stdout.write(f"  mobile_phone not already E.164        : {len(normalise) + len(normalise_skipped)}")
+        self.stdout.write(self.style.SUCCESS(f"  reformattable                         : {len(normalise)}"))
+        self.stdout.write(self.style.WARNING(f"  unparseable, left alone               : {len(normalise_skipped)}"))
+
+        if options["report"]:
+            with open(options["report"], "w", newline="") as fh:
+                writer = csv.writer(fh)
+                writer.writerow(["pass", "id", "email", "value"])
+                writer.writerows(("backfill", *row) for row in backfill_skipped)
+                writer.writerows(("normalise", *row) for row in normalise_skipped)
+            self.stdout.write(f"\nSkipped numbers written to {options['report']}")
+
+        if not commit:
+            self.stdout.write("")
+            for pk, e164 in backfill[:5]:
+                self.stdout.write(f"  backfill  user {pk} -> {e164}")
+            for pk, e164 in normalise[:5]:
+                self.stdout.write(f"  reformat  user {pk} -> {e164}")
+            self.stdout.write("")
+            self.stdout.write(self.style.WARNING("Dry run — nothing written. Re-run with --commit."))
+            return
+
+        total = 0
+        with transaction.atomic():
+            total += self._apply(backfill, "backfill")
+            total += self._apply(normalise, "reformat")
+
+        self.stdout.write(self.style.SUCCESS(f"✅ {total} phone numbers written as E.164."))
+
+    def _collect_backfill(self):
+        """Users with no mobile_phone whose other_phone can be recovered."""
+        rows = (
+            User.objects
+            .filter(mobile_phone__in=["", None])
+            .exclude(Q(other_phone__in=["", None]))
+            .values_list("id", "email", "other_phone")
+            .order_by("id")
+        )
+        return self._split(rows)
+
+    def _collect_normalise(self):
+        """Users who already have a mobile_phone that is not stored as E.164.
+
+        `other_phone` is not consulted here -- an existing number is only ever
+        reformatted, never replaced.
+        """
+        rows = (
+            User.objects
+            .exclude(mobile_phone__in=["", None])
+            .exclude(mobile_phone__startswith="+")
+            .values_list("id", "email", "mobile_phone")
+            .order_by("id")
+        )
+        return self._split(rows)
+
+    def _split(self, rows):
+        """Sort rows into (pk, e164) updates and (pk, email, raw) skips."""
+        updates, skipped = [], []
+        for pk, email, raw in rows:
+            e164 = normalise_irish(raw)
+            if e164 and e164 != raw:
+                updates.append((pk, e164))
+            elif not e164:
+                skipped.append((pk, email, raw))
+        return updates, skipped
+
+    def _apply(self, updates, label):
+        written = 0
+        for start in range(0, len(updates), BATCH_SIZE):
+            batch = updates[start:start + BATCH_SIZE]
+            User.objects.filter(pk__in=[pk for pk, _ in batch]).update(
+                mobile_phone=Case(
+                    *[
+                        When(pk=pk, then=Value(e164, output_field=CharField()))
+                        for pk, e164 in batch
+                    ],
+                    output_field=CharField(),
+                )
+            )
+            written += len(batch)
+            self.stdout.write(f"  {label} {written}/{len(updates)}")
+        return written


### PR DESCRIPTION
## The bug

`PHONENUMBER_DEFAULT_REGION` and `PHONENUMBER_DB_FORMAT` were only ever set in `config/local_settings.py`, which is **gitignored**. Dev and production therefore ran with no default region at all.

Without a region, `PhoneNumberField.get_prep_value` has nothing to parse a bare national number like `0851639462` against. Rather than reject it, the field falls back to storing the raw string — so the number went into the database as unvalidated text and read back as invalid.

Guardian numbers imported from WordPress were in exactly that shape. `sync_users_from_remote` also maps `billing_phone` to `other_phone`, leaving `mobile_phone` blank, and every consumer of a guardian's phone (class lists, admin lists, school exports) reads `mobile_phone` only. The numbers were invisible.

## Changes

**`config/base_settings.py`** — both settings move here so all environments agree. `E164` is chosen over `NATIONAL` because it is what dev and production were already effectively using, and it stays unambiguous even if the region is ever wrong or missing.

**`users/management/commands/normalise_phone_numbers.py`** — one-off repair of the existing data, in two passes:

1. **backfill** — a usable `other_phone` is copied into a blank `mobile_phone`
2. **normalise** — `mobile_phone` values already present are reformatted in place

A populated `mobile_phone` is never replaced, and `other_phone` is never modified or cleared, so the original import stays on record. Unparseable values are left untouched and written to a report rather than guessed at. Dry run by default; `--commit` writes.

One deliberate detail: it writes through `Value(..., output_field=CharField())` rather than assigning to the field. Assigning would reformat via `PHONENUMBER_DB_FORMAT` and make the stored result depend on which settings module happened to be loaded — which is how this bug arose in the first place.

## Already run against production

| | Before | After |
|---|---|---|
| `mobile_phone` blank | 3,024 | 742 |
| stored as E.164 | 1,224 | 5,892 |
| raw / unparseable | 4,690 | 14 |

2,282 recovered, 2,386 reformatted, 47 left for manual follow-up (genuine junk: `0`, `9`, `085 18107072`). Backup at `~/swimtcsp/backups/users_user_before_phonefix_20260807_133442.sql.gz`.

Verified by diffing all 6,648 rows against a pre-run snapshot: **0 `other_phone` values modified, 0 existing `mobile_phone` values replaced.**

## Testing

- A national-format input (`085 163 9462`) now stores as `+353851639462` locally, matching production
- `manage.py check` — only the pre-existing ckeditor warning
- Full suite: 45 tests, 4 errors. **Confirmed pre-existing** by re-running against HEAD with this change stashed — identical four. They are the BOIPA integration tests mocking `get_boipa_session_token`, which no longer exists after the OAuth2 migration. Worth a separate fix.

## Note for reviewers

Because `local_settings.py` is gitignored, any machine with its own copy containing the old `PHONENUMBER_DB_FORMAT = 'NATIONAL'` line will keep writing national format locally until that line is removed.

Production has the data fix applied, but the settings change only takes effect on deploy. Until then, a new signup on production still saves through a field with no default region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)