### PR TITLE
Add search and filters to the bookings overview

### DIFF
--- a/dashboard/templates/dashboard/bookings.html
+++ b/dashboard/templates/dashboard/bookings.html
@@ -12,22 +12,77 @@
       <!-- Category Tabs -->
       <div class="mb-2 border-b border-gray-200">
         <nav class="-mb-px flex space-x-6" aria-label="Tabs">
-          <a href="?category=swims&le_page={{ le_page_obj.number|default:1 }}"
+          <a href="?category=swims{% if qs_filters %}&{{ qs_filters }}{% endif %}"
              class="whitespace-nowrap py-2 px-1 border-b-2 text-sm font-medium {% if category == 'swims' %}border-blue-600 text-blue-700{% else %}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{% endif %}">
             Public Swims
           </a>
-          <a href="?category=lessons&sw_page={{ sw_page_obj.number|default:1 }}"
+          <a href="?category=lessons{% if qs_filters %}&{{ qs_filters }}{% endif %}"
              class="whitespace-nowrap py-2 px-1 border-b-2 text-sm font-medium {% if category == 'lessons' %}border-blue-600 text-blue-700{% else %}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{% endif %}">
             Lessons
           </a>
         </nav>
       </div>
 
+      <!-- Filters -->
+      <form method="get" class="grid grid-cols-1 md:grid-cols-6 gap-3">
+        {% if category %}<input type="hidden" name="category" value="{{ category }}" />{% endif %}
+
+        <input type="text" name="q" value="{{ filters.q }}"
+               placeholder="{% if category == 'swims' %}Search name, email, product or transaction{% else %}Search swimmer, guardian or lesson{% endif %}"
+               class="col-span-1 md:col-span-2 border rounded-md px-3 py-2 text-sm" />
+
+        {% if category != 'lessons' %}
+        <select name="status" class="border rounded-md px-3 py-2 text-sm" title="Applies to swim bookings">
+          <option value="">All statuses</option>
+          <option value="paid" {% if filters.status == 'paid' %}selected{% endif %}>Paid</option>
+          <option value="unpaid" {% if filters.status == 'unpaid' %}selected{% endif %}>Unpaid</option>
+        </select>
+        {% endif %}
+
+        {% if category != 'swims' %}
+        <select name="term" class="border rounded-md px-3 py-2 text-sm" title="Public lesson term">
+          <option value="">All terms</option>
+          {% for term in terms %}
+          <option value="{{ term.id }}" {% if filters.term == term.id|stringformat:"s" %}selected{% endif %}>{{ term.label }}</option>
+          {% endfor %}
+        </select>
+
+        {% if sco_terms %}
+        <select name="sco_term" class="border rounded-md px-3 py-2 text-sm" title="School term">
+          <option value="">All school terms</option>
+          {% for term in sco_terms %}
+          <option value="{{ term.id }}" {% if filters.sco_term == term.id|stringformat:"s" %}selected{% endif %}>
+            {{ term.school.name|default:"School" }} ({{ term.start_date }} → {{ term.end_date }})
+          </option>
+          {% endfor %}
+        </select>
+        {% endif %}
+        {% endif %}
+
+        <input type="date" name="from" value="{{ filters.from }}" class="border rounded-md px-3 py-2 text-sm" title="From date" />
+        <input type="date" name="to" value="{{ filters.to }}" class="border rounded-md px-3 py-2 text-sm" title="To date" />
+
+        <div class="md:col-span-6 flex items-center gap-3">
+          <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white text-sm px-4 py-2 rounded">
+            Apply
+          </button>
+          {% if has_filters %}
+          <a href="?{% if category %}category={{ category }}{% endif %}" class="text-sm text-gray-600 hover:text-gray-900">Reset</a>
+          {% endif %}
+          <span class="text-xs text-gray-500">
+            Dates match the swim date for bookings, and the date enrolled for lessons.
+          </span>
+        </div>
+      </form>
+
       {% if category != 'lessons' %}
       <!-- Public Swim Bookings -->
       <section>
         <div class="flex items-center justify-between mb-3">
-          <h3 class="text-lg font-semibold text-gray-900">Public Swim Bookings</h3>
+          <h3 class="text-lg font-semibold text-gray-900">
+            Public Swim Bookings
+            <span class="ml-2 text-sm font-normal text-gray-500">{{ sw_page_obj.paginator.count }} result{{ sw_page_obj.paginator.count|pluralize }}</span>
+          </h3>
         </div>
 
         <!-- Desktop Table -->
@@ -113,10 +168,10 @@
           <div class="text-sm text-gray-600">Page {{ sw_page_obj.number }} of {{ sw_page_obj.paginator.num_pages }}</div>
           <div class="flex gap-2">
             {% if sw_page_obj.has_previous %}
-              <a href="?category=swims&sw_page={{ sw_page_obj.previous_page_number }}&le_page={{ le_page_obj.number }}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Previous</a>
+              <a href="?sw_page={{ sw_page_obj.previous_page_number }}{% if qs_swim_page %}&{{ qs_swim_page }}{% endif %}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Previous</a>
             {% endif %}
             {% if sw_page_obj.has_next %}
-              <a href="?category=swims&sw_page={{ sw_page_obj.next_page_number }}&le_page={{ le_page_obj.number }}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Next</a>
+              <a href="?sw_page={{ sw_page_obj.next_page_number }}{% if qs_swim_page %}&{{ qs_swim_page }}{% endif %}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Next</a>
             {% endif %}
           </div>
         </div>
@@ -128,7 +183,10 @@
       <!-- School Lesson Enrollments -->
       <section>
         <div class="flex items-center justify-between mb-3">
-          <h3 class="text-lg font-semibold text-gray-900">School Lesson Enrollments</h3>
+          <h3 class="text-lg font-semibold text-gray-900">
+            School Lesson Enrollments
+            <span class="ml-2 text-sm font-normal text-gray-500">{{ sco_page_obj.paginator.count }} result{{ sco_page_obj.paginator.count|pluralize }}</span>
+          </h3>
         </div>
 
         <!-- Desktop Table -->
@@ -183,10 +241,10 @@
           <div class="text-sm text-gray-600">Page {{ sco_page_obj.number }} of {{ sco_page_obj.paginator.num_pages }}</div>
           <div class="flex gap-2">
             {% if sco_page_obj.has_previous %}
-              <a href="?category=lessons&sco_page={{ sco_page_obj.previous_page_number }}&le_page={{ le_page_obj.number }}&sw_page={{ sw_page_obj.number }}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Previous</a>
+              <a href="?sco_page={{ sco_page_obj.previous_page_number }}{% if qs_school_page %}&{{ qs_school_page }}{% endif %}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Previous</a>
             {% endif %}
             {% if sco_page_obj.has_next %}
-              <a href="?category=lessons&sco_page={{ sco_page_obj.next_page_number }}&le_page={{ le_page_obj.number }}&sw_page={{ sw_page_obj.number }}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Next</a>
+              <a href="?sco_page={{ sco_page_obj.next_page_number }}{% if qs_school_page %}&{{ qs_school_page }}{% endif %}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Next</a>
             {% endif %}
           </div>
         </div>
@@ -200,7 +258,10 @@
       <!-- Lesson Enrollments -->
       <section>
         <div class="flex items-center justify-between mb-3">
-          <h3 class="text-lg font-semibold text-gray-900">Lesson Enrollments</h3>
+          <h3 class="text-lg font-semibold text-gray-900">
+            Lesson Enrollments
+            <span class="ml-2 text-sm font-normal text-gray-500">{{ le_page_obj.paginator.count }} result{{ le_page_obj.paginator.count|pluralize }}</span>
+          </h3>
         </div>
 
         <!-- Desktop Table -->
@@ -263,10 +324,10 @@
           <div class="text-sm text-gray-600">Page {{ le_page_obj.number }} of {{ le_page_obj.paginator.num_pages }}</div>
           <div class="flex gap-2">
             {% if le_page_obj.has_previous %}
-              <a href="?category=lessons&le_page={{ le_page_obj.previous_page_number }}&sw_page={{ sw_page_obj.number }}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Previous</a>
+              <a href="?le_page={{ le_page_obj.previous_page_number }}{% if qs_lesson_page %}&{{ qs_lesson_page }}{% endif %}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Previous</a>
             {% endif %}
             {% if le_page_obj.has_next %}
-              <a href="?category=lessons&le_page={{ le_page_obj.next_page_number }}&sw_page={{ sw_page_obj.number }}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Next</a>
+              <a href="?le_page={{ le_page_obj.next_page_number }}{% if qs_lesson_page %}&{{ qs_lesson_page }}{% endif %}" class="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200">Next</a>
             {% endif %}
           </div>
         </div>

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1018,43 +1018,167 @@ def bookings_overview(request):
             category = 'swims'
     except Exception:
         pass
+
+    search = request.GET.get('q', '').strip()
+    status = request.GET.get('status', '').strip()  # "paid" | "unpaid" | ""
+    selected_term = request.GET.get('term', '').strip()
+    selected_sco_term = request.GET.get('sco_term', '').strip()
+    date_from = request.GET.get('from', '').strip()
+    date_to = request.GET.get('to', '').strip()
+
+    def parse_day(value):
+        try:
+            return datetime.strptime(value, "%Y-%m-%d").date()
+        except ValueError:
+            return None
+
+    from_day = parse_day(date_from) if date_from else None
+    to_day = parse_day(date_to) if date_to else None
+
+    # Enrollments carry a timestamp, not a date. Compare against aware datetimes rather
+    # than using __date, which truncates in the database and needs MySQL's timezone
+    # tables loaded — they are not.
+    created_from = timezone.make_aware(datetime.combine(from_day, dt_time.min)) if from_day else None
+    created_to = (
+        timezone.make_aware(datetime.combine(to_day + timedelta(days=1), dt_time.min))
+        if to_day else None
+    )
+
     # Public Swim bookings (have a concrete booking date)
     swim_bookings = (
         SwimOrder.objects.select_related('user', 'product')
         .filter(booking__isnull=False)
         .order_by('-booking', '-created')
     )
+    if search:
+        swim_bookings = swim_bookings.annotate(
+            booker_name=Concat(
+                Coalesce('user__first_name', Value('')),
+                Value(' '),
+                Coalesce('user__last_name', Value('')),
+            ),
+        ).filter(
+            Q(booker_name__icontains=search)
+            | Q(user__email__icontains=search)
+            | Q(product__name__icontains=search)
+            | Q(txId__icontains=search)
+        )
+    # Only swim bookings get a payment status filter: nearly every lesson enrollment
+    # predates the current order system and has no order attached to read `paid` from.
+    if status == 'paid':
+        swim_bookings = swim_bookings.filter(paid=True)
+    elif status == 'unpaid':
+        swim_bookings = swim_bookings.filter(paid=False)
+    if from_day:
+        swim_bookings = swim_bookings.filter(booking__gte=from_day)
+    if to_day:
+        swim_bookings = swim_bookings.filter(booking__lte=to_day)
+
     sw_page_num = request.GET.get('sw_page')
     sw_paginator = Paginator(swim_bookings, 25)
     sw_page_obj = sw_paginator.get_page(sw_page_num)
 
     # Lesson enrollments (public)
     lesson_enrollments = (
-        LessonEnrollment.objects.select_related('lesson', 'swimling', 'term')
+        LessonEnrollment.objects.select_related('lesson', 'swimling', 'term', 'swimling__guardian')
         .order_by('-created')
     )
+    if search:
+        lesson_enrollments = lesson_enrollments.annotate(
+            swimmer_name=Concat(
+                Coalesce('swimling__first_name', Value('')),
+                Value(' '),
+                Coalesce('swimling__last_name', Value('')),
+            ),
+            guardian_name=Concat(
+                Coalesce('swimling__guardian__first_name', Value('')),
+                Value(' '),
+                Coalesce('swimling__guardian__last_name', Value('')),
+            ),
+        ).filter(
+            Q(swimmer_name__icontains=search)
+            | Q(guardian_name__icontains=search)
+            | Q(swimling__guardian__email__icontains=search)
+            | Q(lesson__name__icontains=search)
+        )
+    if selected_term:
+        try:
+            lesson_enrollments = lesson_enrollments.filter(term_id=int(selected_term))
+        except (TypeError, ValueError):
+            pass
+    if created_from:
+        lesson_enrollments = lesson_enrollments.filter(created__gte=created_from)
+    if created_to:
+        lesson_enrollments = lesson_enrollments.filter(created__lt=created_to)
+
     le_page_num = request.GET.get('le_page')
     le_paginator = Paginator(lesson_enrollments, 25)
     le_page_obj = le_paginator.get_page(le_page_num)
 
     # School enrollments
+    sco_terms = []
     try:
-        from schools_bookings.models import ScoEnrollment
+        from schools_bookings.models import ScoEnrollment, ScoTerm
         school_enrollments = (
             ScoEnrollment.objects.select_related('lesson', 'swimling', 'term', 'order')
             .order_by('-created')
         )
+        if search:
+            school_enrollments = school_enrollments.annotate(
+                swimmer_name=Concat(
+                    Coalesce('swimling__first_name', Value('')),
+                    Value(' '),
+                    Coalesce('swimling__last_name', Value('')),
+                ),
+            ).filter(
+                Q(swimmer_name__icontains=search)
+                | Q(lesson__name__icontains=search)
+                | Q(term__school__name__icontains=search)
+            )
+        if selected_sco_term:
+            try:
+                school_enrollments = school_enrollments.filter(term_id=int(selected_sco_term))
+            except (TypeError, ValueError):
+                pass
+        if created_from:
+            school_enrollments = school_enrollments.filter(created__gte=created_from)
+        if created_to:
+            school_enrollments = school_enrollments.filter(created__lt=created_to)
+
         sco_page_num = request.GET.get('sco_page')
         sco_paginator = Paginator(school_enrollments, 25)
         sco_page_obj = sco_paginator.get_page(sco_page_num)
+        sco_terms = ScoTerm.objects.select_related('school').order_by('-start_date', '-id')
     except Exception:
         sco_page_obj = None
+
+    def querystring_without(*keys):
+        """Preserve the current filters in a link while replacing one page number."""
+        params = request.GET.copy()
+        for key in keys:
+            params.pop(key, None)
+        return params.urlencode()
 
     context = {
         'sw_page_obj': sw_page_obj,
         'le_page_obj': le_page_obj,
         'sco_page_obj': sco_page_obj,
         'category': category,
+        'filters': {
+            'q': search,
+            'status': status,
+            'term': selected_term,
+            'sco_term': selected_sco_term,
+            'from': date_from,
+            'to': date_to,
+        },
+        'has_filters': any([search, status, selected_term, selected_sco_term, date_from, date_to]),
+        'terms': Term.objects.all(),
+        'sco_terms': sco_terms,
+        'qs_swim_page': querystring_without('sw_page'),
+        'qs_lesson_page': querystring_without('le_page'),
+        'qs_school_page': querystring_without('sco_page'),
+        'qs_filters': querystring_without('category', 'sw_page', 'le_page', 'sco_page'),
     }
     return render(request, 'dashboard/bookings.html', context)
 


### PR DESCRIPTION
Staff reported that Orders → Bookings needed a search box and filter options. The page listed all three booking tables with nothing but a tab and a page number, so finding one family meant paging through 23,974 lesson enrolments and 6,548 swim bookings by eye.

## What this adds

A filter bar whose controls follow the visible tab:

- **Search** — booker name, email, product and transaction ID on swims; swimmer name, guardian name, guardian email and lesson name on public lesson enrolments; swimmer, lesson and school name on school enrolments. Names go through a `Concat` annotation so "Clodagh Ruane" finds the row that `first_name` and `last_name` cannot match separately.
- **Term** — filtered per table, since public lessons and school lessons have separate term models.
- **Payment status** — swim bookings only.
- **Date range** — swim date for bookings, date enrolled for lessons. Labelled on screen so it isn't ambiguous.
- Result counts beside each heading, and a Reset link that keeps your tab.

## Two decisions worth reviewing

**Payment status is swims-only on purpose.** 23,862 of the 23,974 lesson enrolments predate the current order system and carry no order at all, so a paid/unpaid filter over them would hide 99.5% of the table rather than narrow it. Swim orders have `paid` on the row itself.

**The date filters avoid `__date` lookups.** Enrolments store a timestamp, and `__date` truncates in the database, which needs MySQL's timezone tables loaded — they are not. Aware datetimes are compared instead. Same constraint that ruled out `date_hierarchy` on the school orders admin in #200.

## Bug fixed along the way

The tab and pagination hrefs were built from hardcoded query strings, so every filter was discarded the moment you paged or switched tab. They now rebuild from the request, each preserving all parameters except the page number being replaced.

## Verification

Against local data (23,974 lesson enrolments, 6,548 swim bookings, 81 school):

| Check | Result |
|---|---|
| `term=51` | 1,425 rows — matches the raw count, no row on the page outside that term |
| `q=Ruane` | 63 lessons / 5 swims, all genuinely Ruane |
| `q=Clodagh Ruane` | 17 — full-name search works |
| `term=51&q=Ruane` | 4 — filters compose |
| `term=notanumber` | falls back to unfiltered, no error |
| Paging under a filter | `?le_page=2&category=lessons&q=Ruane` — filter survives |

Full suite unchanged at 45 tests with the same 4 pre-existing BOIPA mock errors. `makemigrations --check` clean; no models changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)