### PR TITLE
Fix the deploy scripts stranding a deploy they cannot finish

### DIFF
--- a/deploy-to-dev.sh
+++ b/deploy-to-dev.sh
@@ -4,23 +4,126 @@
 
 set -e  # Exit on error
 
+DEV_HOST="ssh.eu.pythonanywhere.com"
+DEV_DIR="dev-swimtcsp"
+DEV_VENV="../.virtualenvs/dev-swimtcsp"
+DEV_SETTINGS="config.development_settings"
+DEV_WSGI="/var/www/dev-morganmck_eu_pythonanywhere_com_wsgi.py"
+
 echo "🚀 Starting deployment to dev-morganmck.eu.pythonanywhere.com..."
 
-# Deploy to PythonAnywhere dev server
-ssh ssh.eu.pythonanywhere.com "cd dev-swimtcsp && \
-  echo '📦 Stashing local changes...' && \
-  git stash && \
-  echo '⬇️  Pulling latest code from GitHub...' && \
-  git pull origin main && \
-  echo '🐍 Activating virtual environment...' && \
-  source ../.virtualenvs/dev-swimtcsp/bin/activate && \
-  echo '💾 Running database migrations...' && \
-  python manage.py migrate --settings=config.development_settings && \
-  echo '📂 Collecting static files...' && \
-  python manage.py collectstatic --noinput --settings=config.development_settings && \
-  echo '🔄 Reloading web app...' && \
-  touch /var/www/dev-morganmck_eu_pythonanywhere_com_wsgi.py && \
-  echo '✅ Deployment complete!'"
+# Sent as a quoted heredoc so the remote shell evaluates $(...) and $$, rather
+# than this one expanding them before the command is sent.
+DEPLOY_SCRIPT=$(cat << 'ENDSSH'
+set -e
+
+cd DEV_DIR_PLACEHOLDER
+
+echo '📦 Stashing local changes...'
+git stash
+
+echo '🔍 Checking for untracked files in the way of the pull...'
+git fetch origin main
+
+# The dev server carries migration files generated here and never committed. When
+# one shares a path with a file an incoming commit adds, git refuses to overwrite
+# it and the pull aborts. Move any such file aside: git is about to write its own
+# copy of that exact path, and the original is kept so nothing is lost. Git
+# refuses even when the contents are byte-identical, so comparing first would not
+# let us skip this.
+MIGRATION_BACKUPS="../dev-migration-backups"
+git diff --name-only HEAD origin/main | sort > /tmp/tcsp_dev_incoming.$$
+git status --short --untracked-files=all | grep '^??' | sed 's/^?? //' | sort > /tmp/tcsp_dev_untracked.$$
+COLLISIONS=$(comm -12 /tmp/tcsp_dev_incoming.$$ /tmp/tcsp_dev_untracked.$$)
+rm -f /tmp/tcsp_dev_incoming.$$ /tmp/tcsp_dev_untracked.$$
+
+if [ -n "$COLLISIONS" ]; then
+    mkdir -p "$MIGRATION_BACKUPS"
+    echo '⚠️  Moving these aside first:'
+    echo "$COLLISIONS" | while read -r f; do
+        DEST="$MIGRATION_BACKUPS/$(echo "$f" | tr '/' '_').$(date +%Y%m%d-%H%M%S)"
+        cp "$f" "$DEST"
+        if git show "origin/main:$f" | diff -q - "$f" >/dev/null 2>&1; then
+            echo "   $f (identical to incoming) → $DEST"
+        else
+            # Worth saying out loud: the copy being replaced was not the same file.
+            echo "   $f (DIFFERS from incoming) → $DEST"
+        fi
+        rm -f "$f"
+    done
+else
+    echo '   none'
+fi
+
+echo '⬇️  Pulling latest code from GitHub...'
+git pull origin main
+git log --oneline -1
+
+echo '🐍 Activating virtual environment...'
+source DEV_VENV_PLACEHOLDER/bin/activate
+
+# Dev has migration branches the repo does not, the same way production does. A
+# migration arriving from the repo alongside one of dev's own leaves two leaf
+# nodes, and migrate then refuses to run at all. Merge only when a conflict is
+# actually detected, and only for the apps that have one: running
+# makemigrations --merge on a clean graph falls through to ordinary
+# makemigrations, which could invent migrations from whatever the models say.
+echo '🔍 Checking for conflicting migration leaves...'
+CONFLICT_APPS=$(python - <<'PYEOF'
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "DEV_SETTINGS_PLACEHOLDER")
+django.setup()
+from django.db import connections, DEFAULT_DB_ALIAS
+from django.db.migrations.loader import MigrationLoader
+loader = MigrationLoader(connections[DEFAULT_DB_ALIAS])
+print(" ".join(sorted(loader.detect_conflicts())))
+PYEOF
+)
+
+if [ -n "$CONFLICT_APPS" ]; then
+    echo "⚠️  Conflicting leaves in: $CONFLICT_APPS"
+    python manage.py makemigrations --merge --noinput $CONFLICT_APPS --settings=DEV_SETTINGS_PLACEHOLDER || {
+        echo '❌ Could not merge — aborting before the schema is touched'
+        exit 1
+    }
+    STILL_CONFLICTING=$(python - <<'PYEOF'
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "DEV_SETTINGS_PLACEHOLDER")
+django.setup()
+from django.db import connections, DEFAULT_DB_ALIAS
+from django.db.migrations.loader import MigrationLoader
+loader = MigrationLoader(connections[DEFAULT_DB_ALIAS])
+print(" ".join(sorted(loader.detect_conflicts())))
+PYEOF
+)
+    if [ -n "$STILL_CONFLICTING" ]; then
+        echo "❌ Still conflicting after merge: $STILL_CONFLICTING — aborting"
+        exit 1
+    fi
+    echo '✅ Merge migration created'
+else
+    echo '   none'
+fi
+
+echo '💾 Running database migrations...'
+python manage.py migrate --settings=DEV_SETTINGS_PLACEHOLDER
+
+echo '📂 Collecting static files...'
+python manage.py collectstatic --noinput --settings=DEV_SETTINGS_PLACEHOLDER
+
+echo '🔄 Reloading web app...'
+touch DEV_WSGI_PLACEHOLDER
+
+echo '✅ Deployment complete!'
+ENDSSH
+)
+
+DEPLOY_SCRIPT="${DEPLOY_SCRIPT//DEV_DIR_PLACEHOLDER/$DEV_DIR}"
+DEPLOY_SCRIPT="${DEPLOY_SCRIPT//DEV_VENV_PLACEHOLDER/$DEV_VENV}"
+DEPLOY_SCRIPT="${DEPLOY_SCRIPT//DEV_SETTINGS_PLACEHOLDER/$DEV_SETTINGS}"
+DEPLOY_SCRIPT="${DEPLOY_SCRIPT//DEV_WSGI_PLACEHOLDER/$DEV_WSGI}"
+
+ssh ${DEV_HOST} "${DEPLOY_SCRIPT}"
 
 echo ""
 echo "✨ Your dev server has been updated!"

--- a/deploy-to-production.sh
+++ b/deploy-to-production.sh
@@ -157,6 +157,15 @@ echo -e "${YELLOW}════════════════════�
 
 source PRODUCTION_VENV_PLACEHOLDER/bin/activate
 
+# Stash BEFORE enabling maintenance, not after. The mode is stored in the tracked
+# file config/maintenance_mode_state.txt, so a stash taken afterwards captures the
+# "on" state as a local change and reverts the file — putting the site straight
+# back to live. Every deploy before this one therefore migrated against a site
+# that was still serving, and left the stash behind, which is where the backlog
+# of stashes came from.
+echo -e "${BLUE}📦 Stashing local changes...${NC}"
+git stash
+
 echo -e "${BLUE}🔒 Enabling maintenance mode...${NC}"
 python manage.py maintenance_mode on --settings=PRODUCTION_SETTINGS_PLACEHOLDER || {
     echo -e "${RED}❌ Failed to enable maintenance mode${NC}"
@@ -169,12 +178,49 @@ echo -e "${YELLOW}════════════════════�
 echo -e "${YELLOW}STEP 3: Pull Latest Code${NC}"
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
 
-echo -e "${BLUE}📦 Stashing local changes...${NC}"
-git stash
+git fetch origin main
+
+# Production carries migration files that were generated here and never committed.
+# When one shares a path with a file an incoming commit adds, git refuses to
+# overwrite it and the pull aborts — with the site already in maintenance. Move
+# any such file aside: git is about to write its own copy of that exact path, and
+# the original is kept so nothing is lost. Git refuses even when the contents are
+# byte-identical, so this cannot be skipped by comparing first.
+MIGRATION_BACKUPS="../prod-migration-backups"
+git diff --name-only HEAD origin/main | sort > /tmp/tcsp_incoming.$$
+git status --short --untracked-files=all | grep '^??' | sed 's/^?? //' | sort > /tmp/tcsp_untracked.$$
+COLLISIONS=$(comm -12 /tmp/tcsp_incoming.$$ /tmp/tcsp_untracked.$$)
+rm -f /tmp/tcsp_incoming.$$ /tmp/tcsp_untracked.$$
+
+if [ -n "$COLLISIONS" ]; then
+    mkdir -p "$MIGRATION_BACKUPS"
+    echo -e "${YELLOW}⚠️  Untracked files in the way of the pull:${NC}"
+    echo "$COLLISIONS" | while read -r f; do
+        DEST="$MIGRATION_BACKUPS/$(echo "$f" | tr '/' '_').$(date +%Y%m%d-%H%M%S)"
+        cp "$f" "$DEST"
+        if git show "origin/main:$f" | diff -q - "$f" >/dev/null 2>&1; then
+            echo -e "   ${BLUE}$f${NC} (identical to incoming) → $DEST"
+        else
+            # Worth saying out loud: the copy being replaced was not the same file.
+            echo -e "   ${YELLOW}$f (DIFFERS from incoming)${NC} → $DEST"
+        fi
+        rm -f "$f"
+    done
+fi
+
 echo -e "${BLUE}⬇️  Pulling latest code...${NC}"
 git pull origin main
 git log --oneline -1
-echo -e "${GREEN}✅ Code updated${NC}"
+
+# Assert maintenance mode rather than assume it. The flag lives in a tracked file,
+# so the pull can move it, and everything after this point changes the schema.
+python manage.py maintenance_mode on --settings=PRODUCTION_SETTINGS_PLACEHOLDER >/dev/null 2>&1 || true
+MAINT_STATE=$(cat config/maintenance_mode_state.txt 2>/dev/null || echo "unknown")
+if [ "$MAINT_STATE" != "1" ]; then
+    echo -e "${RED}❌ Maintenance mode is '${MAINT_STATE}', not 1 — aborting before the schema changes${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✅ Code updated, maintenance mode confirmed on${NC}"
 echo ""
 
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
@@ -187,16 +233,72 @@ echo -e "${GREEN}✅ Dependencies updated${NC}"
 echo ""
 
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
-echo -e "${YELLOW}STEP 5: Run Database Migrations${NC}"
+echo -e "${YELLOW}STEP 5: Reconcile Migration Branches${NC}"
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
 
+# Production's migration history has branches the repo does not, and deliberately
+# so — see the "Commit the missing lessons price migration" commit for why they
+# are not committed. When a migration arrives from the repo alongside one of
+# production's own, the app is left with two leaf nodes and migrate refuses to run
+# at all, which would strand the deploy here with the site already down.
+#
+# Only merge when a conflict is actually detected, and only for the apps that have
+# one. Running makemigrations --merge unconditionally is not safe: on a graph with
+# no conflicts it falls through to ordinary makemigrations, which could invent
+# migrations on production from whatever the models happen to say.
+echo -e "${BLUE}🔍 Checking for conflicting migration leaves...${NC}"
+CONFLICT_APPS=$(python - <<'PYEOF'
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "PRODUCTION_SETTINGS_PLACEHOLDER")
+django.setup()
+from django.db import connections, DEFAULT_DB_ALIAS
+from django.db.migrations.loader import MigrationLoader
+loader = MigrationLoader(connections[DEFAULT_DB_ALIAS])
+print(" ".join(sorted(loader.detect_conflicts())))
+PYEOF
+)
+
+if [ -n "$CONFLICT_APPS" ]; then
+    echo -e "${YELLOW}⚠️  Conflicting leaves in: ${CONFLICT_APPS}${NC}"
+    python manage.py makemigrations --merge --noinput $CONFLICT_APPS --settings=PRODUCTION_SETTINGS_PLACEHOLDER || {
+        echo -e "${RED}❌ Could not merge — aborting before the schema is touched${NC}"
+        exit 1
+    }
+
+    # A merge that did not actually resolve the conflict must not reach migrate.
+    STILL_CONFLICTING=$(python - <<'PYEOF'
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "PRODUCTION_SETTINGS_PLACEHOLDER")
+django.setup()
+from django.db import connections, DEFAULT_DB_ALIAS
+from django.db.migrations.loader import MigrationLoader
+loader = MigrationLoader(connections[DEFAULT_DB_ALIAS])
+print(" ".join(sorted(loader.detect_conflicts())))
+PYEOF
+)
+    if [ -n "$STILL_CONFLICTING" ]; then
+        echo -e "${RED}❌ Still conflicting after merge: ${STILL_CONFLICTING} — aborting${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✅ Merge migration created${NC}"
+else
+    echo -e "${GREEN}✅ No migration conflicts${NC}"
+fi
+echo ""
+
+echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
+echo -e "${YELLOW}STEP 6: Run Database Migrations${NC}"
+echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
+
+echo -e "${BLUE}💾 Showing what will be applied...${NC}"
+python manage.py migrate --plan --settings=PRODUCTION_SETTINGS_PLACEHOLDER 2>/dev/null | grep -A100 "Planned operations" || echo "   (no pending migrations)"
 echo -e "${BLUE}💾 Running migrations...${NC}"
 python manage.py migrate --settings=PRODUCTION_SETTINGS_PLACEHOLDER
 echo -e "${GREEN}✅ Migrations complete${NC}"
 echo ""
 
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
-echo -e "${YELLOW}STEP 6: Rebuild FAQ Embeddings${NC}"
+echo -e "${YELLOW}STEP 7: Rebuild FAQ Embeddings${NC}"
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
 
 echo -e "${BLUE}🤖 Re-vectorizing FAQs...${NC}"
@@ -212,7 +314,7 @@ echo -e "${GREEN}✅ FAQ embeddings rebuilt${NC}"
 echo ""
 
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
-echo -e "${YELLOW}STEP 7: Collect Static Files${NC}"
+echo -e "${YELLOW}STEP 8: Collect Static Files${NC}"
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
 
 echo -e "${BLUE}📂 Collecting static files...${NC}"
@@ -221,7 +323,7 @@ echo -e "${GREEN}✅ Static files collected${NC}"
 echo ""
 
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
-echo -e "${YELLOW}STEP 8: Reload Web Application${NC}"
+echo -e "${YELLOW}STEP 9: Reload Web Application${NC}"
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
 
 echo -e "${BLUE}🔄 Reloading web app...${NC}"
@@ -230,7 +332,7 @@ echo -e "${GREEN}✅ Web app reloaded${NC}"
 echo ""
 
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
-echo -e "${YELLOW}STEP 9: Disable Maintenance Mode${NC}"
+echo -e "${YELLOW}STEP 10: Disable Maintenance Mode${NC}"
 echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
 
 echo -e "${BLUE}🔓 Disabling maintenance mode...${NC}"


### PR DESCRIPTION
Three faults, all hit while deploying the swim check-in migration (#203) to production. Each one strands a deploy partway through, and one of them had been silently wrong on every deploy to date.

## 1. Maintenance mode never actually took effect

The mode is stored in the **tracked** file `config/maintenance_mode_state.txt`. The production script enabled it and then ran `git stash` — which captured the "on" state as a local change and reverted the file. The site went straight back to live.

**Every production deploy so far has migrated against a site that was still serving customers**, and left a stash behind each time. That is where the backlog of 40 stashes on production came from.

Fixed by stashing first, then enabling, and **asserting** the flag reads `1` after the pull rather than assuming it — the pull can move a tracked file too. If it doesn't read `1`, the deploy stops before the schema is touched.

## 2. The pull aborted on untracked files

Both servers carry migration files generated there and never committed — deliberately, see the reasoning in #201. When one shares a path with a file an incoming commit adds, git refuses to overwrite it and the pull aborts. On production that happened **after maintenance mode was on**, which is precisely the state the script must never leave the site in.

Now detected before the pull, copied to a backup directory, and moved aside — git is about to write its own copy of that path. Git refuses even when the bytes are identical, so comparing first would not let us skip it. The log states which files *differed* from the incoming version, so a genuinely different file is visible rather than silently swapped.

## 3. Migrations refused to run at all

A migration arriving from the repo beside one of the server's own leaves two leaf nodes, and `migrate` aborts with `Conflicting migrations detected` — again mid-deploy, with the site down.

Both scripts now detect conflicting leaves via Django's `MigrationLoader` and merge **only** the apps that actually have one. That condition matters: `makemigrations --merge` on a clean graph falls through to ordinary `makemigrations`, which could invent migrations on a live server from whatever the models happen to say. The check is repeated after merging and the deploy stops if it didn't resolve. Production also prints the migration plan before applying it.

The dev script moves to the same quoted-heredoc form as production — the old single chained `ssh "..."` string could not hold this logic without the local shell expanding `$(...)` and `$$` before sending. Its existing steps are otherwise unchanged.

## Verification

| Check | Result |
|---|---|
| `bash -n`, both scripts, before and after placeholder substitution | valid; 0 placeholders left |
| Conflict detector on a clean graph | empty — no false positives |
| Conflict detector against production's real migration files | `swims_orders` |
| Synthetic repo: pull with a colliding untracked file, no guard | aborts, reproducing the production failure |
| Same, with the guard | backs up, flags `DIFFERS`, pull succeeds, original preserved |
| Byte-identical collision | still blocks git, and is handled |
| Rewritten dev script run end to end against the dev server | no collisions, no conflicts, nothing pending, site 200 |

## Not included

The 40 existing stashes on production. The reorder stops new ones accruing, but clearing the backlog is a separate destructive step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)