### PR TITLE
Require a phone number on Google signups too

### DIFF
--- a/config/base_settings.py
+++ b/config/base_settings.py
@@ -367,6 +367,12 @@ SOCIALACCOUNT_PROVIDERS = {
 ACCOUNT_FORMS = {
     'signup': 'users.forms.CustomSignupForm',
 }
+# Without this, a Google signup uses allauth's stock form and asks for no phone
+# number, so the requirement on the email signup form was only ever half of the
+# door. SOCIALACCOUNT_AUTO_SIGNUP is False, so this form is genuinely shown.
+SOCIALACCOUNT_FORMS = {
+    'signup': 'users.forms.CustomSocialSignupForm',
+}
 SOCIALACCOUNT_ADAPTER = "users.adapters.AutoLinkSocialAccountAdapter"
 
 # # CrispyForms

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from allauth.account.forms import SignupForm
+from allauth.socialaccount.forms import SignupForm as SocialSignupForm
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import Group
 from django.contrib.auth import get_user_model
@@ -12,12 +13,60 @@ from django_recaptcha.widgets import ReCaptchaV2Checkbox
 User = get_user_model()
 
 
-class CustomSignupForm(SignupForm):
+def irish_phone_field():
+    """The signup phone field, built here so both signup paths share one definition.
+
+    A function rather than an attribute on the mixin below: Django's form metaclass
+    only collects fields declared on the class being defined and on bases that
+    already carry `declared_fields`, so a field set on a plain mixin never reaches
+    form.fields and would silently not render.
+    """
+    return PhoneNumberField(
+        region='IE',
+        required=True,
+        label="Phone Number",
+        help_text="Irish numbers only (e.g. 085..., 01..., or +353 ...)",
+    )
+
+
+class IrishPhoneSignupMixin:
+    """Validates the signup phone number and stores it on the user.
+
+    Shared between the email and Google signup paths. Google signups collected no
+    phone at all until this was added, so every social signup reopened the gap the
+    normalise_phone_numbers backfill had just closed: a guardian on a class list
+    with no way to reach them.
+    """
+
+    def clean_phone_number(self):
+        number = self.cleaned_data.get('phone_number')
+        if not number:
+            raise ValidationError("Phone number is required.")
+
+        # getattr, because an unparseable entry arrives as a plain string with no
+        # country_code rather than raising.
+        if getattr(number, 'country_code', None) != 353:
+            raise ValidationError("Please enter an Irish phone number (+353 or 0...).")
+
+        return number
+
+    def save(self, request):
+        user = super().save(request)
+
+        phone = self.cleaned_data.get('phone_number')
+        if phone:
+            user.mobile_phone = phone
+            user.save(update_fields=['mobile_phone'])
+
+        return user
+
+
+class CustomSignupForm(IrishPhoneSignupMixin, SignupForm):
     first_name = forms.CharField(max_length=150, required=True)
     last_name = forms.CharField(max_length=150, required=True)
     lessons = forms.BooleanField(label="I wish to sign up for swimming lessons.",
                                  required=False)
-    phone_number = PhoneNumberField(region='IE', required=True, label="Phone Number", help_text="Irish numbers only (e.g. 085..., 01..., or +353 ...)")
+    phone_number = irish_phone_field()
     captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox())
 
     def __init__(self, *args, **kwargs):
@@ -28,27 +77,9 @@ class CustomSignupForm(SignupForm):
             "Must be 8+ characters, not too common or all numbers."
         )
 
-    def clean_phone_number(self):
-        number = self.cleaned_data.get('phone_number')
-        # Ensure it is an Irish number only
-        if not number:
-            raise ValidationError("Phone number is required.")
-        try:
-            if getattr(number, 'country_code', None) != 353:
-                raise ValidationError("Please enter an Irish phone number (+353 or 0...).")
-        except Exception:
-            raise ValidationError("Please enter a valid Irish phone number.")
-        return number
-
     def save(self, request):
-        # Call the parent save method to create the user instance
+        # The mixin creates the user and stores the phone number.
         user = super().save(request)
-
-        # Persist phone number (Irish only) to user's mobile_phone
-        phone = self.cleaned_data.get('phone_number')
-        if phone:
-            user.mobile_phone = phone
-            user.save(update_fields=['mobile_phone'])
 
         # Check if the 'lessons' checkbox is checked
         if self.cleaned_data.get('lessons', False):
@@ -59,6 +90,14 @@ class CustomSignupForm(SignupForm):
 
         # Return the user instance
         return user
+
+
+class CustomSocialSignupForm(IrishPhoneSignupMixin, SocialSignupForm):
+    """Google signup, which allauth otherwise completes with whatever the provider
+    returns — never a phone number. No captcha here: the provider has already
+    established there is a person behind the request."""
+
+    phone_number = irish_phone_field()
 
 
 # Update Profile - NO USERNAME

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,108 @@
-from django.test import TestCase
+"""Tests for the signup forms, focused on the phone number.
 
-# Create your tests here.
+Guardians are contacted by phone about classes, so a signup path that does not
+collect one produces an account nobody can reach. The Google path collected none
+at all until CustomSocialSignupForm existed.
+"""
+from unittest.mock import patch
+
+from allauth.socialaccount.models import SocialAccount, SocialLogin
+from allauth.socialaccount.views import SignupView
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase
+
+from users.forms import CustomSignupForm, CustomSocialSignupForm
+
+User = get_user_model()
+
+
+def make_sociallogin(email="googler@test.com"):
+    return SocialLogin(
+        user=User(email=email, first_name="Goo", last_name="Gler"),
+        account=SocialAccount(provider="google", uid="123", extra_data={"email": email}),
+    )
+
+
+class GoogleSignupPhoneTests(TestCase):
+    def setUp(self):
+        self.sociallogin = make_sociallogin()
+
+    def bound(self, phone):
+        return CustomSocialSignupForm(
+            data={"email": "googler@test.com", "phone_number": phone},
+            sociallogin=self.sociallogin,
+        )
+
+    def test_allauth_uses_our_form(self):
+        """The setting has to be wired, or the stock form silently takes over and
+        asks for nothing but an email address."""
+        self.assertIs(SignupView().get_form_class(), CustomSocialSignupForm)
+
+    def test_the_form_asks_for_a_phone_number(self):
+        form = CustomSocialSignupForm(sociallogin=self.sociallogin)
+        self.assertIn("phone_number", form.fields)
+        self.assertTrue(form.fields["phone_number"].required)
+
+    def test_signup_without_a_phone_number_is_rejected(self):
+        form = self.bound("")
+        self.assertFalse(form.is_valid())
+        self.assertIn("phone_number", form.errors)
+
+    def test_a_non_irish_number_is_rejected_with_a_useful_message(self):
+        form = self.bound("+442071838750")
+        self.assertFalse(form.is_valid())
+        self.assertIn("Irish phone number", " ".join(form.errors["phone_number"]))
+
+    def test_a_national_format_irish_number_is_accepted(self):
+        form = self.bound("0851639462")
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_an_e164_irish_number_is_accepted(self):
+        form = self.bound("+353851639462")
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_the_number_is_stored_on_the_user(self):
+        """Stored as E.164, and on mobile_phone — the field every class list,
+        admin list and school export actually reads."""
+        form = self.bound("0851639462")
+        self.assertTrue(form.is_valid(), form.errors)
+
+        user = User.objects.create_user(
+            email="googler@test.com", password="x", first_name="Goo",
+        )
+        request = RequestFactory().post("/accounts/social/signup/")
+
+        # Patch allauth's own user creation: this asserts what our mixin does with
+        # the user, not how allauth builds one from a sociallogin.
+        with patch(
+            "allauth.socialaccount.forms.SignupForm.save", return_value=user
+        ):
+            saved = form.save(request)
+
+        saved.refresh_from_db()
+        self.assertEqual(str(saved.mobile_phone), "+353851639462")
+
+
+class EmailSignupPhoneTests(TestCase):
+    """The email path already required a phone; its validation and saving moved to
+    the shared mixin, so it is checked here against regression."""
+
+    def bound(self, phone):
+        return CustomSignupForm(data={
+            "email": "parent@test.com",
+            "first_name": "Pat",
+            "last_name": "Parent",
+            "password1": "swimming-pool-42",
+            "password2": "swimming-pool-42",
+            "phone_number": phone,
+        })
+
+    def test_a_non_irish_number_is_still_rejected(self):
+        form = self.bound("+442071838750")
+        self.assertFalse(form.is_valid())
+        self.assertIn("Irish phone number", " ".join(form.errors["phone_number"]))
+
+    def test_a_missing_number_is_still_rejected(self):
+        form = self.bound("")
+        self.assertFalse(form.is_valid())
+        self.assertIn("phone_number", form.errors)


### PR DESCRIPTION
Closing the last hole in the phone-number work.

## The gap

The email signup form has required an Irish phone number since it was written — but `SOCIALACCOUNT_FORMS` was never set, so a **Google signup used allauth's stock form**. Checked against the installed allauth, that form's field list is exactly `['email']`.

`SOCIALACCOUNT_AUTO_SIGNUP` is `False`, so the form genuinely is shown to the user. It simply never had a phone field on it.

Every Google signup therefore created a guardian with a blank `mobile_phone` — the field class lists, admin lists and school exports all read. It quietly reopened the gap the `normalise_phone_numbers` backfill had just closed for 2,282 existing guardians.

## The fix

`CustomSocialSignupForm`, with `SOCIALACCOUNT_FORMS` pointed at it. Validation and persistence live in a mixin the two forms share, so the paths can't drift apart again. No captcha on the social form — the provider has already established there's a person behind the request.

Two implementation notes worth a reviewer's eye:

- **The phone field is built by a function, not declared on the mixin.** Django's form metaclass only collects fields from the class being defined and from bases already carrying `declared_fields`. A field set on a plain mixin never reaches `form.fields` — it would have silently failed to render, which is exactly the failure mode this PR exists to fix.
- **Moving the validation surfaced a dead error message.** The Irish-number check raised `ValidationError` inside a `try` whose `except Exception` caught it and re-raised the generic *"Please enter a valid Irish phone number"*, so the specific message naming `+353` was unreachable. Nothing in there could raise anyway — the check reads `country_code` via `getattr` — so the `try` is gone and the useful message now shows.

## Verification

| Check | Result |
|---|---|
| allauth's `SignupView` resolves our form | `CustomSocialSignupForm` |
| stock allauth form fields | `['email']` — the gap, confirmed |
| our form fields | `['email', 'phone_number']`, phone required |
| blank number | rejected |
| non-Irish (`+44…`) | rejected, with the message naming +353 |
| `0851639462` and `+353851639462` | both accepted |
| after save | `mobile_phone` is `+353851639462` |

The email path's rejection cases are covered against regression, since its validation moved into the mixin.

Suite is **64 tests, up from 55**, with the same 4 pre-existing BOIPA mock errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)