### PR TITLE
Stop a term with a blank booking date taking down every page

### DIFF
--- a/utils/context_processors.py
+++ b/utils/context_processors.py
@@ -39,12 +39,22 @@ def get_term_info(request: HttpRequest) -> Dict[str, str]:
     # 🧠 Determine active modes
     active_modes = []
 
+    # Every date on Term is nullable, and get_current_term() selects on start_date
+    # and end_date alone — so a term can be the current one while its rebooking or
+    # booking date is still blank. Comparing against None raises, and this runs as
+    # a context processor, so it would take down every page on the site rather than
+    # just the booking pages. Guard each comparison by the dates it actually uses,
+    # the way Term.determine_phase already does.
+    #
+    # A missing date leaves active_modes empty, which reads as no phase: banners
+    # disappear and the cart gate (which admits 'RB' only) refuses. Incomplete
+    # dates therefore close booking rather than open it.
     if current_term:
-        if today < rebooking_date:
+        if rebooking_date and today < rebooking_date:
             active_modes = ['BK']
-        elif rebooking_date <= today < booking_date:
+        elif rebooking_date and booking_date and rebooking_date <= today < booking_date:
             active_modes = ['BK', 'RB']
-        elif booking_date <= today <= current_term.end_date:
+        elif booking_date and current_term.end_date and booking_date <= today <= current_term.end_date:
             active_modes = ['BN']
 
     # 📌 Choose dominant phase for backward compatibility (e.g., RB takes priority over BK)

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,0 +1,103 @@
+"""Tests for the term context processor.
+
+get_term_info runs on every page. Every date on Term is nullable, and
+get_current_term() selects on start_date and end_date alone, so a term can be the
+current one with its rebooking or booking date still blank. Comparing a date
+against None raises, and from a context processor that takes down the whole site.
+"""
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from lessons_bookings.models import Term
+from utils.context_processors import get_term_info
+
+
+class TermPhaseDateGuardTests(TestCase):
+    def setUp(self):
+        self.today = date.today()
+
+    def info_for(self, term):
+        """Run the context processor against one term, without touching the DB."""
+        data = {
+            'current_term': term,
+            'next_term': None,
+            'previous_term': None,
+            'today': self.today,
+        }
+        with patch('utils.context_processors.get_term_context_data', return_value=data):
+            return get_term_info(None)
+
+    def term(self, **dates):
+        defaults = {
+            'start_date': self.today - timedelta(days=10),
+            'end_date': self.today + timedelta(days=10),
+            'rebooking_date': self.today - timedelta(days=5),
+            'booking_date': self.today + timedelta(days=5),
+        }
+        defaults.update(dates)
+        return Term(id=999, **defaults)
+
+    def test_a_term_with_every_date_still_resolves_its_phase(self):
+        """The guards must not change the answer when the dates are all present."""
+        info = self.info_for(self.term())
+
+        self.assertEqual(info['current_phase_id'], 'RB')
+        self.assertEqual(info['active_modes'], ['BK', 'RB'])
+
+    def test_before_rebooking_opens(self):
+        info = self.info_for(self.term(rebooking_date=self.today + timedelta(days=2)))
+        self.assertEqual(info['current_phase_id'], 'BK')
+
+    def test_once_booking_is_open(self):
+        info = self.info_for(self.term(
+            rebooking_date=self.today - timedelta(days=5),
+            booking_date=self.today - timedelta(days=1),
+        ))
+        self.assertEqual(info['current_phase_id'], 'BN')
+
+    def test_a_missing_rebooking_date_does_not_raise(self):
+        info = self.info_for(self.term(rebooking_date=None))
+
+        self.assertIsNone(info['current_phase_id'])
+        self.assertEqual(info['active_modes'], [])
+        self.assertEqual(info['banners'], [])
+
+    def test_a_missing_booking_date_does_not_raise(self):
+        info = self.info_for(self.term(booking_date=None))
+
+        self.assertIsNone(info['current_phase_id'])
+        self.assertEqual(info['active_modes'], [])
+
+    def test_a_missing_end_date_does_not_raise(self):
+        info = self.info_for(self.term(
+            rebooking_date=self.today - timedelta(days=5),
+            booking_date=self.today - timedelta(days=1),
+            end_date=None,
+        ))
+
+        self.assertIsNone(info['current_phase_id'])
+        self.assertEqual(info['active_modes'], [])
+
+    def test_a_term_with_no_dates_at_all_does_not_raise(self):
+        info = self.info_for(self.term(
+            start_date=None, end_date=None, rebooking_date=None, booking_date=None,
+        ))
+
+        self.assertIsNone(info['current_phase_id'])
+        self.assertEqual(info['active_modes'], [])
+
+    def test_no_current_term_does_not_raise(self):
+        info = self.info_for(None)
+
+        self.assertIsNone(info['current_phase_id'])
+        self.assertEqual(info['current_term'], "No current term")
+
+    def test_an_incomplete_term_closes_booking_rather_than_opening_it(self):
+        """The safe direction. shopping_cart admits phase 'RB' only, so an empty
+        phase refuses rebooking instead of letting it through."""
+        info = self.info_for(self.term(booking_date=None))
+
+        self.assertNotEqual(info['current_phase_id'], 'RB')
+        self.assertNotEqual(info['current_phase_id'], 'BN')


### PR DESCRIPTION
`get_term_info` compared `today` against `rebooking_date`, `booking_date` and `end_date` with no check that they were set.

Every date on `Term` is nullable, and `get_current_term()` selects on `start_date` and `end_date` alone — so a term can be **the current one** while its rebooking or booking date is still blank. That's the normal state of a term someone has just created and hasn't finished filling in.

Comparing a date against `None` raises, and **this is a context processor**. It runs on every page, so the failure wouldn't be confined to booking pages — the whole site would 500 until the date was filled in.

Reproduced directly:

```
TypeError: '<' not supported between instances of 'datetime.date' and 'NoneType'
```

`Term.determine_phase` already guards each comparison, so the two disagreed about the same question. This makes them agree.

## Behaviour when a date is missing

`active_modes` is left empty, which reads as no phase: banners disappear and the cart gate — which admits `'RB'` only — refuses. **Incomplete dates close booking rather than open it**, which is the safe direction.

## How real is it

Not currently firing on production, but not theoretical either: **22 of the 61 terms there have no rebooking or booking date.** They're all historic imports from 2014–2016, so none is the current term today. The next term saved without those dates would be.

`term_status_for_active_schools` compares dates the same way and is deliberately left alone — `ScoTerm.start_date` and `end_date` are not nullable, so there's nothing to guard.

## Tests

Nine, covering the phase still resolving correctly with every date present, and each of `rebooking_date` / `booking_date` / `end_date` missing, plus a term with no dates at all and no current term.

The five None cases **fail against the unguarded code**. The four complete-date cases pass either way — which is what shows the guards didn't change the answer for a well-formed term.

Suite is **76 tests, up from 67**, with the same 4 pre-existing BOIPA mock errors.

## Note

Adjacent, not included: `Term.get_phase_code()` (`lessons_bookings/models.py:106`) is dead code with inverted logic — it tests `booking_date <= today < rebooking_date`, which can never be true since `rebooking_date` precedes `booking_date`. Nothing calls it. Worth deleting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)