### PR TITLE
Stop a stale Tailwind stylesheet reaching production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,15 @@ python manage.py runserver
 
 # Frontend build (Tailwind CSS)
 npm install
-npm run build  # Watches ./static/src/input.css and rebuilds on changes (continuous)
+npm run build:css   # One-shot build of ./static/css/styles.css
+npm run watch:css   # Same, but rebuilds continuously while you work
+npm run build       # Alias for build:css
+
+# static/css/styles.css is committed, and PythonAnywhere has no Node, so it can
+# only be built here. Tailwind emits only the classes it finds when it runs, so a
+# class added to a template without a rebuild is silently missing from the
+# deployed CSS — no error, just an unstyled element. Rebuild and commit the CSS
+# whenever you add classes; deploy-to-production.sh refuses to deploy a stale one.
 
 # Collect static files (for production)
 python manage.py collectstatic
@@ -283,7 +291,7 @@ app_name/
 2. Ensure `.env` file is configured (use `.env.example` as template)
 3. Run migrations if models changed
 4. Start Django dev server on default port 8000
-5. In separate terminal, run `npm run build` for Tailwind watch mode
+5. In separate terminal, run `npm run watch:css` for Tailwind watch mode
 6. Access site at `http://localhost:8000`
 
 ### Making Changes to Models

--- a/deploy-to-production.sh
+++ b/deploy-to-production.sh
@@ -67,6 +67,41 @@ fi
 echo -e "${GREEN}✅ Git checks passed${NC}"
 echo ""
 
+# Tailwind stylesheet freshness.
+#
+# static/css/styles.css is a committed artifact, and PythonAnywhere has no Node,
+# so it can only be built here. Tailwind emits just the classes it finds when it
+# runs, which means a class added to a template since the last build is silently
+# missing from the deployed stylesheet — no error, just an unstyled element. The
+# chat panel shipped full-width exactly this way.
+#
+# Rebuild to a temporary file and compare. This never writes to the working tree
+# and never commits: a deploy quietly amending a tracked file is worse than one
+# that stops and says what to do.
+if command -v npx >/dev/null 2>&1 && [ -d node_modules ]; then
+    echo -e "${YELLOW}🎨 Checking the Tailwind stylesheet is current${NC}"
+    TMP_CSS=$(mktemp -t tcsp_styles)
+    if npx tailwindcss -i ./static/src/input.css -o "$TMP_CSS" >/dev/null 2>&1; then
+        if ! cmp -s "$TMP_CSS" static/css/styles.css; then
+            rm -f "$TMP_CSS"
+            echo -e "${RED}❌ static/css/styles.css is out of date${NC}"
+            echo -e "${YELLOW}   A class used in a template is missing from the built stylesheet.${NC}"
+            echo -e "${YELLOW}   Run:  npm run build:css${NC}"
+            echo -e "${YELLOW}   then commit and push static/css/styles.css, and deploy again.${NC}"
+            exit 1
+        fi
+        echo -e "${GREEN}✅ Stylesheet is up to date${NC}"
+    else
+        # A broken build must not block a deploy of unrelated Python changes.
+        echo -e "${YELLOW}⚠️  Could not run Tailwind — skipping the stylesheet check${NC}"
+    fi
+    rm -f "$TMP_CSS"
+else
+    echo -e "${YELLOW}⚠️  Node or node_modules missing — skipping the stylesheet check${NC}"
+    echo -e "${YELLOW}   Run 'npm install' if you edit templates on this machine.${NC}"
+fi
+echo ""
+
 # Confirmation prompt (skipped for automated deployment)
 echo -e "${RED}⚠️  WARNING: You are about to deploy to PRODUCTION${NC}"
 echo -e "${YELLOW}   This will affect live users at www.tcsp.ie${NC}"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "tailwindcss": "^3.4.7"
   },
   "scripts": {
-    "build": "npx tailwindcss -i ./static/src/input.css -o ./static/css/styles.css --watch"
+    "build:css": "npx tailwindcss -i ./static/src/input.css -o ./static/css/styles.css",
+    "watch:css": "npx tailwindcss -i ./static/src/input.css -o ./static/css/styles.css --watch",
+    "build": "npm run build:css"
   },
   "dependencies": {
     "daisyui": "^5.0.46",

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -632,6 +632,10 @@ video {
   visibility: visible;
 }
 
+.invisible {
+  visibility: hidden;
+}
+
 .collapse {
   visibility: collapse;
 }
@@ -825,6 +829,10 @@ video {
   order: 2;
 }
 
+.col-span-1 {
+  grid-column: span 1 / span 1;
+}
+
 .col-span-2 {
   grid-column: span 2 / span 2;
 }
@@ -888,6 +896,10 @@ video {
   margin-bottom: -1px;
 }
 
+.-ml-px {
+  margin-left: -1px;
+}
+
 .mb-1 {
   margin-bottom: 0.25rem;
 }
@@ -938,6 +950,10 @@ video {
 
 .ml-1 {
   margin-left: 0.25rem;
+}
+
+.ml-10 {
+  margin-left: 2.5rem;
 }
 
 .ml-2 {
@@ -1132,6 +1148,14 @@ video {
   height: 16rem;
 }
 
+.h-7 {
+  height: 1.75rem;
+}
+
+.h-72 {
+  height: 18rem;
+}
+
 .h-8 {
   height: 2rem;
 }
@@ -1182,6 +1206,10 @@ video {
 
 .max-h-\[500px\] {
   max-height: 500px;
+}
+
+.max-h-\[55vh\] {
+  max-height: 55vh;
 }
 
 .max-h-\[70vh\] {
@@ -1256,6 +1284,10 @@ video {
   width: 6rem;
 }
 
+.w-28 {
+  width: 7rem;
+}
+
 .w-3 {
   width: 0.75rem;
 }
@@ -1268,12 +1300,20 @@ video {
   width: 1rem;
 }
 
+.w-40 {
+  width: 10rem;
+}
+
 .w-5 {
   width: 1.25rem;
 }
 
 .w-6 {
   width: 1.5rem;
+}
+
+.w-7 {
+  width: 1.75rem;
 }
 
 .w-72 {
@@ -1286,6 +1326,10 @@ video {
 
 .w-80 {
   width: 20rem;
+}
+
+.w-\[min\(\.\.\.\)\] {
+  width: min(...);
 }
 
 .w-fit {
@@ -1349,12 +1393,28 @@ video {
   max-width: 80rem;
 }
 
+.max-w-\[100px\] {
+  max-width: 100px;
+}
+
 .max-w-\[120px\] {
   max-width: 120px;
 }
 
 .max-w-\[12rem\] {
   max-width: 12rem;
+}
+
+.max-w-\[140px\] {
+  max-width: 140px;
+}
+
+.max-w-\[160px\] {
+  max-width: 160px;
+}
+
+.max-w-\[200px\] {
+  max-width: 200px;
 }
 
 .max-w-full {
@@ -1739,11 +1799,6 @@ video {
   border-color: rgb(219 234 254 / 0.5);
 }
 
-.divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
-  --tw-divide-opacity: 1;
-  border-color: rgb(29 78 216 / var(--tw-divide-opacity));
-}
-
 .divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
   --tw-divide-opacity: 1;
   border-color: rgb(243 244 246 / var(--tw-divide-opacity));
@@ -1930,6 +1985,11 @@ video {
   border-color: rgb(253 230 138 / var(--tw-border-opacity));
 }
 
+.border-amber-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(245 158 11 / var(--tw-border-opacity));
+}
+
 .border-blue-100 {
   --tw-border-opacity: 1;
   border-color: rgb(219 234 254 / var(--tw-border-opacity));
@@ -2020,6 +2080,11 @@ video {
 .border-gray-300 {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
+}
+
+.border-gray-400 {
+  --tw-border-opacity: 1;
+  border-color: rgb(156 163 175 / var(--tw-border-opacity));
 }
 
 .border-green-100 {
@@ -2376,6 +2441,11 @@ video {
 .bg-gray-800 {
   --tw-bg-opacity: 1;
   background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+}
+
+.bg-gray-900 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(17 24 39 / var(--tw-bg-opacity));
 }
 
 .bg-green-100 {
@@ -2821,6 +2891,12 @@ video {
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
 
+.from-emerald-500 {
+  --tw-gradient-from: #10b981 var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(16 185 129 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
 .from-emerald-600 {
   --tw-gradient-from: #059669 var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(5 150 105 / 0) var(--tw-gradient-to-position);
@@ -3039,6 +3115,11 @@ video {
 .via-cyan-400 {
   --tw-gradient-to: rgb(34 211 238 / 0)  var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), #22d3ee var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+
+.via-cyan-600 {
+  --tw-gradient-to: rgb(8 145 178 / 0)  var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), #0891b2 var(--tw-gradient-via-position), var(--tw-gradient-to);
 }
 
 .via-green-500 {
@@ -3638,6 +3719,10 @@ video {
   vertical-align: middle;
 }
 
+.font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 .text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;
@@ -3708,6 +3793,10 @@ video {
 
 .uppercase {
   text-transform: uppercase;
+}
+
+.lowercase {
+  text-transform: lowercase;
 }
 
 .italic {
@@ -3871,6 +3960,11 @@ video {
   color: rgb(209 250 229 / var(--tw-text-opacity));
 }
 
+.text-emerald-600 {
+  --tw-text-opacity: 1;
+  color: rgb(5 150 105 / var(--tw-text-opacity));
+}
+
 .text-emerald-700 {
   --tw-text-opacity: 1;
   color: rgb(4 120 87 / var(--tw-text-opacity));
@@ -3879,6 +3973,11 @@ video {
 .text-emerald-800 {
   --tw-text-opacity: 1;
   color: rgb(6 95 70 / var(--tw-text-opacity));
+}
+
+.text-gray-200 {
+  --tw-text-opacity: 1;
+  color: rgb(229 231 235 / var(--tw-text-opacity));
 }
 
 .text-gray-300 {
@@ -4285,6 +4384,16 @@ video {
   --tw-shadow: var(--tw-shadow-colored);
 }
 
+.outline {
+  outline-style: solid;
+}
+
+.ring {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
 .ring-1 {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
@@ -4373,6 +4482,12 @@ video {
   backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 }
 
+.backdrop-blur-xl {
+  --tw-backdrop-blur: blur(24px);
+  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+
 .transition {
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
@@ -4447,6 +4562,20 @@ video {
   transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 
+.first\:ml-0:first-child {
+  margin-left: 0px;
+}
+
+.first\:rounded-l-lg:first-child {
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.last\:rounded-r-lg:last-child {
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
 .last\:border-b-0:last-child {
   border-bottom-width: 0px;
 }
@@ -4489,6 +4618,11 @@ video {
 
 .hover\:border-blue-300\/50:hover {
   border-color: rgb(147 197 253 / 0.5);
+}
+
+.hover\:border-blue-400:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(96 165 250 / var(--tw-border-opacity));
 }
 
 .hover\:border-gray-300:hover {
@@ -5342,6 +5476,10 @@ video {
   --tw-ring-color: rgb(100 116 139 / var(--tw-ring-opacity));
 }
 
+.focus\:ring-white\/70:focus {
+  --tw-ring-color: rgb(255 255 255 / 0.7);
+}
+
 .focus\:ring-yellow-200:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(254 240 138 / var(--tw-ring-opacity));
@@ -5738,6 +5876,14 @@ video {
 
   .md\:col-span-5 {
     grid-column: span 5 / span 5;
+  }
+
+  .md\:col-span-6 {
+    grid-column: span 6 / span 6;
+  }
+
+  .md\:mb-0 {
+    margin-bottom: 0px;
   }
 
   .md\:ml-2 {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,24 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  // Tailwind only emits the classes it finds here. Anything used but not scanned
+  // is silently absent from the built stylesheet — no error, just an unstyled
+  // element — so this list needs to cover every place a class name can appear.
   content: [
     './*/templates/**/*.html',   // Django app templates
     './templates/**/*.html',     // Project-level templates
     './**/*.html',              // Catch-all HTML files
     './static/js/**/*.js',      // JavaScript files
+    // static/chatbot/chat.js builds the chat bubbles in JavaScript, so its class
+    // names live nowhere else. They only survived earlier builds because the same
+    // classes happened to appear in a template too. Named specifically rather
+    // than './static/**/*.js', which also sweeps vendored DataTables and Django
+    // admin scripts and invents classes from words inside their strings.
+    './static/chatbot/**/*.js',
   ],
+  // Known gap, deliberately not scanned: a couple of views build small HTML
+  // fragments in Python (finances/views.py). Adding './**/*.py' would walk .venv
+  // on every build. Those fragments use only common classes; if that changes,
+  // add the file here rather than the whole tree.
   theme: {
     extend: {},
   },


### PR DESCRIPTION
`static/css/styles.css` is a committed artifact, and **PythonAnywhere has no Node** — so it can only be built on a developer machine. The only build script was a `--watch`, nothing rebuilt it on the way out, and the committed file was last generated on **2025-11-15**.

Tailwind emits only the classes it finds when it runs. Every class added to a template since then was silently absent from the deployed stylesheet — no error, no warning, just an element with no styling. The chat panel shipped at the full width of the screen for exactly this reason.

## Three parts

**A one-shot build.** `npm run build:css` builds and exits; `npm run watch:css` is the old watcher. `npm run build` now aliases the one-shot — a `build` that never terminates is the surprising half of this, since anything automated that ran it would hang rather than build.

**A guard in the production deploy's pre-flight**, which runs locally where Node is. It rebuilds to a temp file and compares, refusing to deploy a stale stylesheet and naming the command to fix it.

It deliberately does **not** write to the working tree or commit — a deploy quietly amending a tracked file is worse than one that stops and explains. If Node or `node_modules` is missing, or Tailwind fails, it warns and continues rather than blocking a deploy of unrelated Python changes.

**A gap in the content globs.** `static/chatbot/chat.js` builds the chat bubbles in JavaScript, so `bg-blue-200` and `text-blue-900` exist nowhere else — they survived past builds only because the same classes happened to appear in a template too. Scanned specifically rather than via `./static/**/*.js`, which also sweeps vendored DataTables and Django admin scripts and invented `.table-caption` and `.invert` from words inside their strings.

## What the rebuild changed

Adds roughly **3 KB** of classes that were in use but missing. Drops exactly one selector, `.divide-blue-700`, which the attendance sheet rewrite stopped using.

Checked that every class `chat.js` needs survives, and that the few Tailwind classes embedded in `finances/views.py` are present — Python isn't scanned, and adding `./**/*.py` would walk `.venv` on every build, so that's noted in the config instead.

## Verification

Both directions, since a guard that only passes proves nothing:

| Case | Result |
|---|---|
| Freshly built stylesheet | passes |
| Template gains a class, no rebuild | **aborts**, naming `npm run build:css` |
| Working tree after either | untouched |

Suite unchanged at **76 tests** with the same 4 pre-existing BOIPA mock errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)