### PR TITLE
Stop emoji causing a 500, by moving the schema to utf8mb4

### DIFF
--- a/config/development_settings.py
+++ b/config/development_settings.py
@@ -41,7 +41,12 @@ DATABASES = {
         'USER': 'morganmck',
         'PASSWORD': config("DB_PASSWORD"),
         'HOST': 'morganmck.mysql.eu.pythonanywhere-services.com',
-        'OPTIONS': {'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"},
+        # See the note in production_settings: the schema is utf8mb4, so the
+        # connection says so explicitly rather than relying on a driver default.
+        'OPTIONS': {
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+            'charset': 'utf8mb4',
+        },
     }
 }
 

--- a/config/production_settings.py
+++ b/config/production_settings.py
@@ -50,7 +50,13 @@ DATABASES = {
         'USER': 'morganmck',
         'PASSWORD': config("DB_PASSWORD"),
         'HOST': 'morganmck.mysql.eu.pythonanywhere-services.com',
-        'OPTIONS': {'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"},
+        # charset is explicit rather than left to the driver's default: the
+        # schema is utf8mb4 (users migration 0017) and a connection negotiating
+        # anything narrower would reintroduce the four-byte failure it fixed.
+        'OPTIONS': {
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+            'charset': 'utf8mb4',
+        },
     }
 }
 

--- a/users/migrations/0017_utf8mb4_conversion.py
+++ b/users/migrations/0017_utf8mb4_conversion.py
@@ -1,0 +1,84 @@
+"""Convert the whole schema from utf8mb3 to utf8mb4.
+
+The database was created with utf8mb3, which holds at most three bytes per
+character and therefore cannot store anything outside the Basic Multilingual
+Plane — emoji, most obviously. MySQL does not truncate silently under
+STRICT_TRANS_TABLES; it raises, so the write fails and the customer gets a 500.
+
+Found via the chatbot, where a reply containing 😺 produced
+
+    (1366, "Incorrect string value: '\\xF0\\x9F\\x98\\xBA' for column 'response'")
+
+but the chatbot is only where it happened to surface. 157 columns across 47
+tables were utf8mb3, so the same failure was reachable from any free-text field
+a person can type into — a swimling's name, a guardian's note, the medical box.
+
+It lives in `users` because the migration is database-wide and has to live
+somewhere; `users` holds the free text most likely to carry an emoji.
+
+Every table is converted, not just Django's app tables. Leaving any behind would
+strand it on utf8mb3_general_ci, and a join across two different collations is
+an "Illegal mix of collations" error — a worse fault than the one being fixed.
+The database default is changed too, so tables created later inherit utf8mb4
+rather than quietly reintroducing the problem.
+
+Safe to run here specifically because MySQL is 8.0 and every table is DYNAMIC
+row format: the index prefix limit is 3072 bytes, not the old 767, and the
+widest indexed column in this schema is VARCHAR(255) — 1020 bytes as utf8mb4.
+Re-check that before assuming this migration is portable to another database.
+
+Irreversible by design. Going back to utf8mb3 would fail on, or silently
+mangle, any four-byte character stored in the meantime.
+"""
+from django.db import migrations
+
+CHARSET = "utf8mb4"
+COLLATION = "utf8mb4_unicode_ci"
+
+
+def convert_to_utf8mb4(apps, schema_editor):
+    connection = schema_editor.connection
+    if connection.vendor != "mysql":
+        # SQLite is used for the test database and is UTF-8 throughout.
+        return
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT DATABASE()")
+        database = cursor.fetchone()[0]
+
+        cursor.execute(
+            f"ALTER DATABASE `{database}` "
+            f"CHARACTER SET {CHARSET} COLLATE {COLLATION}"
+        )
+
+        # Read the table list up front. Converting a table while iterating a
+        # cursor over information_schema is asking for trouble.
+        cursor.execute(
+            """
+            SELECT TABLE_NAME FROM information_schema.TABLES
+            WHERE TABLE_SCHEMA = %s AND TABLE_TYPE = 'BASE TABLE'
+            ORDER BY TABLE_NAME
+            """,
+            [database],
+        )
+        tables = [row[0] for row in cursor.fetchall()]
+
+        for table in tables:
+            cursor.execute(
+                f"ALTER TABLE `{table}` "
+                f"CONVERT TO CHARACTER SET {CHARSET} COLLATE {COLLATION}"
+            )
+
+
+class Migration(migrations.Migration):
+    # DDL in MySQL commits implicitly, so wrapping this in a transaction would
+    # promise an atomicity that cannot be delivered.
+    atomic = False
+
+    dependencies = [
+        ("users", "0016_swimling_medical_info"),
+    ]
+
+    operations = [
+        migrations.RunPython(convert_to_utf8mb4, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
Asking SplashBot for a joke returned a reply containing 😺, and the insert failed:

```
(1366, "Incorrect string value: '\xF0\x9F\x98\xBA' for column 'response'")
```

The database was created with utf8mb3, which holds three bytes per character and so cannot store anything outside the Basic Multilingual Plane. Under `STRICT_TRANS_TABLES` MySQL does not truncate quietly — it raises, the write fails, and the customer is shown "Something went wrong".

The chatbot is only where it surfaced. **157 columns across 47 tables were utf8mb3**, so the same 500 was reachable from any free-text field a person can type into — a swimling's name, a guardian's note, the medical box added last week. A parent putting an emoji in a child's note would have hit it.

## What this does

- `users/migrations/0017_utf8mb4_conversion.py` converts every table, and the database default with them, to `utf8mb4` / `utf8mb4_unicode_ci`.
- Both server settings now name the connection charset explicitly rather than leaving it to the driver, so a connection cannot negotiate something narrower than the schema it is talking to.

Tables are not converted selectively: one left on `utf8mb3_general_ci` makes any join against it an "Illegal mix of collations" error, which is a worse fault than the one being fixed. Converting the database default too means tables created later inherit utf8mb4 instead of quietly reintroducing the problem.

## Why it's safe here

MySQL is 8.0 with every table `DYNAMIC`, so the index prefix limit is 3072 bytes rather than the old 767, and the widest indexed column in this schema is `VARCHAR(255)` — 1020 bytes as utf8mb4. Re-check that before assuming the migration is portable elsewhere.

Rehearsed against local MySQL first: 157 utf8mb3 columns to 0 in a few seconds on a 34 MB database, with an emoji then stored and read back intact.

The migration is `atomic = False`, because DDL in MySQL commits implicitly and wrapping it in a transaction would promise an atomicity that cannot be delivered. It no-ops on non-MySQL vendors, so the SQLite test database is unaffected.

## Deploying this

- **Irreversible by design.** The reverse is a `noop`: going back to utf8mb3 would fail on, or silently mangle, any four-byte character stored in the meantime. Take a verified backup before running it against production.
- The conversion rewrites every table, so it holds locks for the duration. A few seconds on 34 MB locally; production is the same order of size.
- Production is still on `64810ca1` and has **not** yet had the chatbot rate-limit and spend-cap work (`8654c352`, `e6c43535`) that is already on `main` and live on dev. Merging this first means one deploy carries both. Note that deploy carries its own requirement — `deploy-to-production.sh` runs `createcachetable` after `migrate`, and a manual `git pull` instead of the script would 500 every chat message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
