### PR TITLE
Rebuild the Tailwind stylesheet after the deleted swimlings panel

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -980,10 +980,6 @@ video {
   margin-left: auto;
 }
 
-.mr-0 {
-  margin-right: 0px;
-}
-
 .mr-1 {
   margin-right: 0.25rem;
 }
@@ -1873,10 +1869,6 @@ video {
   overflow-x: hidden;
 }
 
-.overflow-y-hidden {
-  overflow-y: hidden;
-}
-
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2603,10 +2595,6 @@ video {
 
 .bg-red-600\/5 {
   background-color: rgb(220 38 38 / 0.05);
-}
-
-.bg-red-600\/90 {
-  background-color: rgb(220 38 38 / 0.9);
 }
 
 .bg-red-700 {
@@ -5694,10 +5682,6 @@ video {
 
   .sm\:ml-4 {
     margin-left: 1rem;
-  }
-
-  .sm\:mr-2 {
-    margin-right: 0.5rem;
   }
 
   .sm\:mr-3 {


### PR DESCRIPTION
`deploy-to-production.sh` refused to deploy: `static/css/styles.css` no longer matched what Tailwind emits for the current templates.

The difference is four utility classes being dropped — `mr-0`, `overflow-y-hidden`, `bg-red-600/90` and `sm:mr-2` — left stranded when `_swimlings_panel.html` was deleted in 1b478ba2.

Removals only, so nothing loses its styling. Confirmed none of the four is referenced from any template, script or Python file, including anywhere Tailwind's scanner wouldn't look.

Unblocks deploying the chatbot hardening and the utf8mb4 fix to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)