### PR TITLE
Name the alert setting CHATBOT_ABUSE_ALERT_EMAIL, as configured

### DIFF
--- a/chatbot/helpers/alerts.py
+++ b/chatbot/helpers/alerts.py
@@ -30,7 +30,7 @@ COOLDOWN_SECONDS = 60 * 60
 
 def recipients():
     """Who to tell, or [] when alerting is switched off."""
-    configured = getattr(settings, "CHATBOT_ABUSE_ALERT_EMAILS", "") or ""
+    configured = getattr(settings, "CHATBOT_ABUSE_ALERT_EMAIL", "") or ""
     if isinstance(configured, (list, tuple)):
         return [str(a).strip() for a in configured if str(a).strip()]
     return [a.strip() for a in configured.split(",") if a.strip()]

--- a/chatbot/management/commands/check_moderation.py
+++ b/chatbot/management/commands/check_moderation.py
@@ -85,12 +85,12 @@ class Command(BaseCommand):
             else:
                 self.stdout.write(self.style.SUCCESS(f"✅ allowed: {label}"))
 
-        recipients = getattr(settings, "CHATBOT_ABUSE_ALERT_EMAILS", "")
+        recipients = getattr(settings, "CHATBOT_ABUSE_ALERT_EMAIL", "")
         if recipients:
             self.stdout.write(self.style.SUCCESS(f"✅ Alerts go to: {recipients}"))
         else:
             self.stdout.write(self.style.WARNING(
-                "⚠️  CHATBOT_ABUSE_ALERT_EMAILS is empty — messages will be "
+                "⚠️  CHATBOT_ABUSE_ALERT_EMAIL is empty — messages will be "
                 "refused and recorded, but nobody will be told."
             ))
 

--- a/chatbot/tests.py
+++ b/chatbot/tests.py
@@ -659,7 +659,7 @@ class ModerationTests(TestCase):
 
 
 @override_settings(
-    CHATBOT_ABUSE_ALERT_EMAILS="owner@example.com",
+    CHATBOT_ABUSE_ALERT_EMAIL="owner@example.com",
     FAQ_MATCH_THRESHOLD=0.65,
     FAQ_MIN_CONFIDENCE=0.45,
     FAQ_CONTEXT_MIN_SCORE=0.40,
@@ -745,7 +745,7 @@ class BlockedMessageTests(TestCase):
         self.assertEqual(ChatbotQuery.objects.count(), 5)
         self.assertEqual(len(mail.outbox), 1)
 
-    @override_settings(CHATBOT_ABUSE_ALERT_EMAILS="")
+    @override_settings(CHATBOT_ABUSE_ALERT_EMAIL="")
     def test_no_recipients_configured_still_refuses(self):
         with self._flagged():
             response = self._post(self.ABUSE)

--- a/config/base_settings.py
+++ b/config/base_settings.py
@@ -96,11 +96,12 @@ CHATBOT_MODERATION_ENABLED = config('CHATBOT_MODERATION_ENABLED', default=True, 
 # screening off. The throttle bounds the volume instead.
 CHATBOT_MODERATION_MODEL = config('CHATBOT_MODERATION_MODEL', default='gpt-4o-mini')
 
-# Comma-separated addresses told when a message is flagged and refused. Empty
-# disables alerting; the flag is still recorded either way. Rate limited to one
-# email per session per hour by chatbot.helpers.alerts, because a single troll
-# works through many variants in a few minutes.
-CHATBOT_ABUSE_ALERT_EMAILS = config('CHATBOT_ABUSE_ALERT_EMAILS', default='')
+# Who is told when a message is flagged and refused: one address, or several
+# comma separated. Empty disables alerting; the message is still refused and
+# still recorded either way. Rate limited to one email per session per hour by
+# chatbot.helpers.alerts, because a single troll works through many variants in
+# a few minutes.
+CHATBOT_ABUSE_ALERT_EMAIL = config('CHATBOT_ABUSE_ALERT_EMAIL', default='')
 
 # The ceiling on the whole site's model spend, which the per-caller buckets
 # above cannot provide: enough separate visitors add up without any one of them


### PR DESCRIPTION
The setting was read as `CHATBOT_ABUSE_ALERT_EMAILS`, but it is configured in `.env` as `CHATBOT_ABUSE_ALERT_EMAIL`. The names never met, so `recipients()` saw an empty string and no alert would ever have been sent — while `check_moderation` reported the screen itself as working, because it is.

Take the configured name. It still accepts several addresses comma separated; one address is the normal case and the singular reads better for it.

Found on the dev deploy: screening passed all its probes and the alert line said "empty" against a `.env` that plainly had an address in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)