### PR TITLE
Fix reply-to address and make the production deploy survive a dropped connection

### DIFF
--- a/config/base_settings.py
+++ b/config/base_settings.py
@@ -490,6 +490,11 @@ HIJACK_PERMISSION_CHECK = "hijack.permissions.superusers_and_staff"
 
 # Default Email
 DEFAULT_SUPPORT_EMAIL = "swimming@tcsp.ie"
+# Where replies should go. DEFAULT_FROM_EMAIL is the mailbox Django logs into to
+# send (web@), which is not the one anybody reads — so without this, replies to
+# booking confirmations and password resets pile up in the wrong inbox. Applied
+# by utils.email_backend.ReplyToEmailBackend to any message not setting its own.
+DEFAULT_REPLY_TO_EMAIL = config('DEFAULT_REPLY_TO_EMAIL', default=DEFAULT_SUPPORT_EMAIL)
 # Mailchimp
 MAILCHIMP_API_KEY = config("MAILCHIMP_API_KEY")
 MAILCHIMP_SERVER_PREFIX = config("MAILCHIMP_SERVER_PREFIX")

--- a/config/development_settings.py
+++ b/config/development_settings.py
@@ -54,7 +54,7 @@ ALLOWED_HOSTS = ["dev-morganmck.eu.pythonanywhere.com"]
 CSRF_TRUSTED_ORIGINS = ["https://dev-morganmck.eu.pythonanywhere.com"]
 
 # --- Email (M365) ---
-EMAIL_BACKEND       = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_BACKEND       = 'utils.email_backend.ReplyToEmailBackend'
 EMAIL_HOST          = config('EMAIL_HOST')
 EMAIL_PORT          = config('EMAIL_PORT', cast=int)
 EMAIL_USE_TLS       = config('EMAIL_USE_TLS', cast=bool)

--- a/config/production_settings.py
+++ b/config/production_settings.py
@@ -77,7 +77,7 @@ MAINTENANCE_MODE_IGNORE_URLS = (
 )
 
 # --- Email (M365) ---
-EMAIL_BACKEND       = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_BACKEND       = 'utils.email_backend.ReplyToEmailBackend'
 EMAIL_HOST          = config('EMAIL_HOST')
 EMAIL_PORT          = config('EMAIL_PORT', cast=int)
 EMAIL_USE_TLS       = config('EMAIL_USE_TLS', cast=bool)

--- a/deploy-to-production.sh
+++ b/deploy-to-production.sh
@@ -7,6 +7,18 @@
 
 set -e  # Exit on error
 
+# Keep the Mac awake for the whole deploy.
+#
+# The slow steps — mysqldump, pip --upgrade, the FAQ embeddings — run long enough
+# for an idle machine to sleep, which drops the SSH connection mid-deploy. Twice
+# now that has happened with the site already in maintenance mode. `-i` blocks
+# idle sleep only; closing the lid still sleeps, and nothing here can prevent
+# that, which is why the remote half also runs detached.
+if [ "$(uname)" = "Darwin" ] && [ -z "$TCSP_CAFFEINATED" ] && command -v caffeinate >/dev/null 2>&1; then
+    export TCSP_CAFFEINATED=1
+    exec caffeinate -i "$0" "$@"
+fi
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -396,7 +408,73 @@ DEPLOY_SCRIPT="${DEPLOY_SCRIPT//PRODUCTION_VENV_PLACEHOLDER/$PRODUCTION_VENV}"
 DEPLOY_SCRIPT="${DEPLOY_SCRIPT//PRODUCTION_SETTINGS_PLACEHOLDER/$PRODUCTION_SETTINGS}"
 DEPLOY_SCRIPT="${DEPLOY_SCRIPT//PRODUCTION_WSGI_PLACEHOLDER/$PRODUCTION_WSGI}"
 
-ssh ${PRODUCTION_HOST} "${DEPLOY_SCRIPT}"
+# Run the deploy detached on the server, and follow its log from here.
+#
+# Previously this was one `ssh HOST "$DEPLOY_SCRIPT"`, so the deploy was a child
+# of the SSH session: if the laptop slept or the network dropped, the remote
+# shell died wherever it happened to be — most dangerously between STEP 2
+# (maintenance on) and STEP 10 (maintenance off), stranding www.tcsp.ie on the
+# maintenance page with nobody running to fix it.
+#
+# Now the script is copied over and launched under setsid, detached from the
+# connection. Following the log is a separate, disposable SSH: losing it costs
+# nothing, and the deploy runs to completion either way.
+STAMP=$(date +%Y%m%d-%H%M%S)
+REMOTE_SCRIPT="deploy-run-${STAMP}.sh"
+REMOTE_LOG="deploy-${STAMP}.log"
+REMOTE_STATUS="deploy-${STAMP}.status"
+
+# ServerAliveInterval so a stalled connection is noticed rather than hanging the
+# terminal for the TCP timeout.
+SSH_OPTS="-o ServerAliveInterval=30 -o ServerAliveCountMax=6"
+
+echo -e "${BLUE}📤 Sending the deploy script to the server...${NC}"
+printf '%s\n' "$DEPLOY_SCRIPT" | ssh $SSH_OPTS ${PRODUCTION_HOST} "cat > ~/${REMOTE_SCRIPT}"
+
+echo -e "${BLUE}▶️  Launching it detached (survives a dropped connection)...${NC}"
+# The status file is what makes the exit code survive the detach: $? from the
+# deploy is written there, and the follower below reads it back.
+ssh $SSH_OPTS ${PRODUCTION_HOST} "cd ~ && setsid nohup bash -c 'bash ~/${REMOTE_SCRIPT} > ~/${REMOTE_LOG} 2>&1; echo \$? > ~/${REMOTE_STATUS}' < /dev/null > /dev/null 2>&1 &"
+
+echo -e "${GREEN}✅ Deploy is running on the server${NC}"
+echo -e "${YELLOW}   If this terminal dies, the deploy continues. Re-attach with:${NC}"
+echo -e "   ssh ${PRODUCTION_HOST} 'tail -f ~/${REMOTE_LOG}'"
+echo ""
+
+# Follow the log until the status file appears. Written as a remote shell loop so
+# it is one connection rather than a poll-per-second from here.
+set +e
+ssh $SSH_OPTS ${PRODUCTION_HOST} "
+    while [ ! -f ~/${REMOTE_LOG} ]; do sleep 1; done
+    tail -n +1 -f ~/${REMOTE_LOG} &
+    TAIL_PID=\$!
+    while [ ! -f ~/${REMOTE_STATUS} ]; do sleep 2; done
+    sleep 2  # let tail flush the last lines before it is killed
+    kill \$TAIL_PID 2>/dev/null
+    exit \$(cat ~/${REMOTE_STATUS})
+"
+DEPLOY_STATUS=$?
+set -e
+
+# Tidy the run script; keep the log, which is the record of what happened.
+ssh $SSH_OPTS ${PRODUCTION_HOST} "rm -f ~/${REMOTE_SCRIPT}; ls -1t ~/deploy-*.log 2>/dev/null | tail -n +11 | xargs -r rm --" || true
+
+if [ "$DEPLOY_STATUS" -ne 0 ]; then
+    echo ""
+    echo -e "${RED}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${RED}║  ❌ DEPLOYMENT FAILED (exit ${DEPLOY_STATUS})                              ║${NC}"
+    echo -e "${RED}╚════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+    # Said explicitly because a failure after STEP 2 leaves the site down, and
+    # that is not obvious from a wall of log output.
+    echo -e "${YELLOW}⚠️  If it failed after STEP 2, www.tcsp.ie is still in maintenance mode.${NC}"
+    echo -e "${YELLOW}   Check, and clear it once you know why it failed:${NC}"
+    echo -e "   ssh ${PRODUCTION_HOST} 'cat ~/${PRODUCTION_DIR}/config/maintenance_mode_state.txt'"
+    echo -e "   ssh ${PRODUCTION_HOST} 'cd ~/${PRODUCTION_DIR} && source ${PRODUCTION_VENV}/bin/activate && python manage.py maintenance_mode off --settings=${PRODUCTION_SETTINGS}'"
+    echo ""
+    echo -e "${BLUE}   Full log: ssh ${PRODUCTION_HOST} 'less ~/${REMOTE_LOG}'${NC}"
+    exit "$DEPLOY_STATUS"
+fi
 
 echo ""
 echo -e "${GREEN}✨ Production deployment finished!${NC}"

--- a/utils/email_backend.py
+++ b/utils/email_backend.py
@@ -1,0 +1,38 @@
+"""SMTP backend that stamps a default Reply-To on outgoing mail.
+
+Every message leaves as `From: web@tcsp.ie`, because that is the Microsoft 365
+account Django authenticates as. Almost none of them set a Reply-To, so a
+customer hitting Reply on a booking confirmation lands in the web@ mailbox —
+while the body of that same email tells them to write to swimming@tcsp.ie.
+
+Done as a backend rather than a `reply_to=` argument at each send site because
+the send sites are not all ours: allauth's password reset and email
+confirmation go through django.core.mail without ever consulting our code, and
+those are the messages customers are most likely to reply to. A backend catches
+everything that leaves the process, including whatever gets added next.
+
+An explicit Reply-To always wins — see the contact form in home/views.py, which
+sets its own on purpose.
+"""
+from django.conf import settings
+from django.core.mail.backends.smtp import EmailBackend as SMTPEmailBackend
+
+
+class ReplyToEmailBackend(SMTPEmailBackend):
+    """SMTP backend applying settings.DEFAULT_REPLY_TO_EMAIL where none is set."""
+
+    def send_messages(self, email_messages):
+        default = getattr(settings, "DEFAULT_REPLY_TO_EMAIL", "") or ""
+        if default:
+            reply_to = [default] if isinstance(default, str) else list(default)
+            for message in email_messages or []:
+                # `reply_to` is a list on EmailMessage, but a message can arrive
+                # with the header set directly (allauth builds some that way),
+                # and a duplicate Reply-To is worse than none at all.
+                if not getattr(message, "reply_to", None) and not any(
+                    key.lower() == "reply-to"
+                    for key in getattr(message, "extra_headers", {})
+                ):
+                    message.reply_to = reply_to
+
+        return super().send_messages(email_messages)

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,4 +1,4 @@
-"""Tests for the term context processor.
+"""Tests for the term context processor and the outgoing-mail backend.
 
 get_term_info runs on every page. Every date on Term is nullable, and
 get_current_term() selects on start_date and end_date alone, so a term can be the
@@ -8,10 +8,13 @@ against None raises, and from a context processor that takes down the whole site
 from datetime import date, timedelta
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.core.mail import EmailMessage
+from django.core.mail.backends.smtp import EmailBackend as SMTPEmailBackend
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from lessons_bookings.models import Term
 from utils.context_processors import get_term_info
+from utils.email_backend import ReplyToEmailBackend
 
 
 class TermPhaseDateGuardTests(TestCase):
@@ -101,3 +104,65 @@ class TermPhaseDateGuardTests(TestCase):
 
         self.assertNotEqual(info['current_phase_id'], 'RB')
         self.assertNotEqual(info['current_phase_id'], 'BN')
+
+
+class ReplyToBackendTests(SimpleTestCase):
+    """The backend that keeps replies out of the send-only web@ mailbox.
+
+    Django's test runner swaps EMAIL_BACKEND for locmem, so these drive the
+    class directly and stub the SMTP send it inherits.
+    """
+
+    def send(self, *messages):
+        """Run messages through the backend, returning them as it sent them."""
+        backend = ReplyToEmailBackend()
+        with patch.object(SMTPEmailBackend, 'send_messages', return_value=len(messages)):
+            backend.send_messages(list(messages))
+        return messages
+
+    def message(self, **kwargs):
+        kwargs.setdefault('subject', 'Order Confirmation')
+        kwargs.setdefault('body', 'Thank you for your order.')
+        kwargs.setdefault('from_email', 'web@tcsp.ie')
+        kwargs.setdefault('to', ['parent@example.com'])
+        return EmailMessage(**kwargs)
+
+    @override_settings(DEFAULT_REPLY_TO_EMAIL='swimming@tcsp.ie')
+    def test_a_message_without_a_reply_to_gets_the_default(self):
+        message, = self.send(self.message())
+
+        self.assertEqual(message.reply_to, ['swimming@tcsp.ie'])
+
+    @override_settings(DEFAULT_REPLY_TO_EMAIL='swimming@tcsp.ie')
+    def test_an_explicit_reply_to_is_left_alone(self):
+        """home/views.py sets its own on the contact form, deliberately."""
+        message, = self.send(self.message(reply_to=['someone@example.com']))
+
+        self.assertEqual(message.reply_to, ['someone@example.com'])
+
+    @override_settings(DEFAULT_REPLY_TO_EMAIL='swimming@tcsp.ie')
+    def test_a_reply_to_set_as_a_header_is_not_duplicated(self):
+        message, = self.send(self.message(headers={'Reply-To': 'header@example.com'}))
+
+        self.assertEqual(message.reply_to, [])
+        self.assertEqual(message.message()['Reply-To'], 'header@example.com')
+
+    @override_settings(DEFAULT_REPLY_TO_EMAIL='swimming@tcsp.ie')
+    def test_the_header_actually_reaches_the_built_message(self):
+        """The point of the exercise: what the customer's mail client replies to."""
+        message, = self.send(self.message())
+
+        self.assertEqual(message.message()['Reply-To'], 'swimming@tcsp.ie')
+
+    @override_settings(DEFAULT_REPLY_TO_EMAIL='')
+    def test_an_empty_setting_switches_the_behaviour_off(self):
+        message, = self.send(self.message())
+
+        self.assertEqual(message.reply_to, [])
+
+    @override_settings(DEFAULT_REPLY_TO_EMAIL='swimming@tcsp.ie')
+    def test_every_message_in_a_batch_is_stamped(self):
+        first, second = self.send(self.message(), self.message())
+
+        self.assertEqual(first.reply_to, ['swimming@tcsp.ie'])
+        self.assertEqual(second.reply_to, ['swimming@tcsp.ie'])


### PR DESCRIPTION
Two problems found while checking why the last deploy appeared to have been cut short.

## Replies were going to the wrong mailbox

Every email leaves as `From: web@tcsp.ie` — the M365 account Django authenticates as. Only `home/views.py` sets a `Reply-To`, so replies to booking confirmations, waiting-list notices and allauth password resets all landed in `web@`, which nobody reads — while the body of those emails tells customers to write to `swimming@tcsp.ie`.

Fixed with `utils.email_backend.ReplyToEmailBackend`, which stamps `settings.DEFAULT_REPLY_TO_EMAIL` on any message that doesn't set its own. Done as a backend rather than per-send-site because allauth's mail never passes through our code. `DEFAULT_REPLY_TO_EMAIL` defaults to `DEFAULT_SUPPORT_EMAIL`, so no `.env` change is needed on any server.

## A sleeping laptop could strand the live site in maintenance mode

The deploy ran as a child of the SSH session. Maintenance mode goes on at STEP 2 and off at STEP 10, with mysqldump, `pip --upgrade` and the FAQ embeddings in between — long enough for an idle Mac to sleep and drop the connection, killing the remote shell mid-deploy and leaving www.tcsp.ie on the maintenance page.

- `caffeinate -i` re-exec at the top, blocking idle sleep for the duration
- the remote half now runs detached under `setsid`; following the log is a separate, disposable SSH, so a dropped connection no longer stops the deploy
- exit status returns via a status file, and failures now say explicitly that the site may still be in maintenance, with the command to clear it

## Testing

- 6 new tests in `utils/tests.py` covering the default, an explicit `reply_to` winning, no duplicate when set as a raw header, the header reaching the built message, the off switch, and batches
- `python manage.py test utils home chatbot` — 81 tests, all pass
- detach mechanism verified against the real server: live log streaming, exit status propagation (0 and 42), and a job abandoned mid-run that still ran to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)