### PR TITLE
Reply to the enquirer on the contact form, and port the deploy fixes to dev

### DIFF
--- a/deploy-to-dev.sh
+++ b/deploy-to-dev.sh
@@ -4,6 +4,15 @@
 
 set -e  # Exit on error
 
+# Keep the Mac awake for the whole deploy — see deploy-to-production.sh for the
+# full story. Shorter here (no database backup), but pip --upgrade and
+# collectstatic are still enough to let an idle machine sleep and cut the
+# connection mid-migration.
+if [ "$(uname)" = "Darwin" ] && [ -z "$TCSP_CAFFEINATED" ] && command -v caffeinate >/dev/null 2>&1; then
+    export TCSP_CAFFEINATED=1
+    exec caffeinate -i "$0" "$@"
+fi
+
 DEV_HOST="ssh.eu.pythonanywhere.com"
 DEV_DIR="dev-swimtcsp"
 DEV_VENV="../.virtualenvs/dev-swimtcsp"
@@ -130,7 +139,48 @@ DEPLOY_SCRIPT="${DEPLOY_SCRIPT//DEV_VENV_PLACEHOLDER/$DEV_VENV}"
 DEPLOY_SCRIPT="${DEPLOY_SCRIPT//DEV_SETTINGS_PLACEHOLDER/$DEV_SETTINGS}"
 DEPLOY_SCRIPT="${DEPLOY_SCRIPT//DEV_WSGI_PLACEHOLDER/$DEV_WSGI}"
 
-ssh ${DEV_HOST} "${DEPLOY_SCRIPT}"
+# Run detached on the server and follow the log from here, as production does.
+# Dev has no maintenance mode, so a dropped connection cannot strand the site —
+# but it can still kill the run part-way through migrate or collectstatic and
+# leave dev in a state nobody chose. Detaching costs nothing and removes that.
+STAMP=$(date +%Y%m%d-%H%M%S)
+REMOTE_SCRIPT="dev-deploy-run-${STAMP}.sh"
+REMOTE_LOG="dev-deploy-${STAMP}.log"
+REMOTE_STATUS="dev-deploy-${STAMP}.status"
+SSH_OPTS="-o ServerAliveInterval=30 -o ServerAliveCountMax=6"
+
+echo "📤 Sending the deploy script to the server..."
+printf '%s\n' "$DEPLOY_SCRIPT" | ssh $SSH_OPTS ${DEV_HOST} "cat > ~/${REMOTE_SCRIPT}"
+
+echo "▶️  Launching it detached (survives a dropped connection)..."
+ssh $SSH_OPTS ${DEV_HOST} "cd ~ && setsid nohup bash -c 'bash ~/${REMOTE_SCRIPT} > ~/${REMOTE_LOG} 2>&1; echo \$? > ~/${REMOTE_STATUS}' < /dev/null > /dev/null 2>&1 &"
+
+echo "   If this terminal dies, the deploy continues. Re-attach with:"
+echo "   ssh ${DEV_HOST} 'tail -f ~/${REMOTE_LOG}'"
+echo ""
+
+set +e
+ssh $SSH_OPTS ${DEV_HOST} "
+    while [ ! -f ~/${REMOTE_LOG} ]; do sleep 1; done
+    tail -n +1 -f ~/${REMOTE_LOG} &
+    TAIL_PID=\$!
+    while [ ! -f ~/${REMOTE_STATUS} ]; do sleep 2; done
+    sleep 2  # let tail flush the last lines before it is killed
+    kill \$TAIL_PID 2>/dev/null
+    exit \$(cat ~/${REMOTE_STATUS})
+"
+DEPLOY_STATUS=$?
+set -e
+
+# Tidy the run script; keep the log, which is the record of what happened.
+ssh $SSH_OPTS ${DEV_HOST} "rm -f ~/${REMOTE_SCRIPT}; ls -1t ~/dev-deploy-*.log 2>/dev/null | tail -n +11 | xargs -r rm --" || true
+
+if [ "$DEPLOY_STATUS" -ne 0 ]; then
+    echo ""
+    echo "❌ Dev deployment failed (exit ${DEPLOY_STATUS})"
+    echo "   Full log: ssh ${DEV_HOST} 'less ~/${REMOTE_LOG}'"
+    exit "$DEPLOY_STATUS"
+fi
 
 echo ""
 echo "✨ Your dev server has been updated!"

--- a/home/tests.py
+++ b/home/tests.py
@@ -1,3 +1,64 @@
-from django.test import TestCase
+"""Tests for the contact form's outgoing enquiry email.
 
-# Create your tests here.
+The address staff reply to is the whole point of this form. It used to be
+swimming@tcsp.ie — the inbox the enquiry had just arrived in — so answering a
+customer sent the reply back to ourselves.
+"""
+from unittest.mock import patch
+
+from django.core import mail
+from django.test import TestCase
+from django.urls import reverse
+
+
+class ContactFormEmailTests(TestCase):
+    def setUp(self):
+        # The live captcha would need a network round trip. Patching validate()
+        # leaves the rest of the form's cleaning — including the honeypot and the
+        # link limit — doing its real work.
+        patcher = patch(
+            'django_recaptcha.fields.ReCaptchaField.validate', return_value=None
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def submit(self, **overrides):
+        data = {
+            'name': 'Aoife Ryan',
+            'email': 'aoife@example.com',
+            'subject': 'Lesson times',
+            'message': 'Is there a Saturday morning slot for a 6 year old?',
+            'captcha': 'PASSED',
+            'website': '',
+        }
+        data.update(overrides)
+        return self.client.post(reverse('info_section', args=['contact']), data)
+
+    def test_the_enquiry_reaches_the_support_inbox(self):
+        self.submit()
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ['swimming@tcsp.ie'])
+
+    def test_replying_answers_the_person_who_wrote_in(self):
+        self.submit(email='parent@example.com')
+
+        self.assertEqual(mail.outbox[0].reply_to, ['parent@example.com'])
+        self.assertEqual(mail.outbox[0].message()['Reply-To'], 'parent@example.com')
+
+    def test_the_default_reply_to_does_not_overwrite_the_enquirer(self):
+        """The backend's default must lose to the address set here."""
+        self.submit(email='parent@example.com')
+
+        self.assertNotIn('swimming@tcsp.ie', mail.outbox[0].reply_to)
+
+    def test_a_honeypot_submission_sends_nothing(self):
+        response = self.submit(website='http://spam.example.com')
+
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(response.status_code, 200)
+
+    def test_a_message_full_of_links_sends_nothing(self):
+        self.submit(message='http://a.example http://b.example http://c.example')
+
+        self.assertEqual(len(mail.outbox), 0)

--- a/home/views.py
+++ b/home/views.py
@@ -37,12 +37,17 @@ def info_view(request, section=None):
 
             from django.core.mail import EmailMessage
 
+            # Reply-To is the person who wrote in, so hitting Reply in the
+            # support inbox answers them. It used to be swimming@ itself, which
+            # meant replying to an enquiry sent it straight back to ourselves.
+            # Safe to take from the form: ContactForm.email is an EmailField, and
+            # Django rejects newlines in headers regardless.
             email_msg = EmailMessage(
                 subject=f"Contact Us - {subject}",
                 body='',
                 from_email=settings.FROM_EMAIL,
-                to=['swimming@tcsp.ie'],
-                reply_to=['swimming@tcsp.ie'],
+                to=[settings.DEFAULT_SUPPORT_EMAIL],
+                reply_to=[email],
             )
             email_msg.content_subtype = 'html'
             email_msg.body = html_message


### PR DESCRIPTION
Follow-ups to #217, both flagged there.

## Contact form replied to ourselves

`home/views.py` set `reply_to=['swimming@tcsp.ie']` — the inbox the enquiry had just arrived in. Hitting Reply on a customer's question addressed it straight back to support, so answering anyone meant copying their address out of the message body by hand.

Now `reply_to=[email]`, the address they typed. Safe to take from the form: `ContactForm.email` is an `EmailField`, and Django refuses newlines in headers regardless. The hardcoded `to=['swimming@tcsp.ie']` becomes `settings.DEFAULT_SUPPORT_EMAIL` so the support address lives in one place.

## deploy-to-dev.sh had neither fix from #217

Ported both: the `caffeinate -i` re-exec, and the detached `setsid` run with the log followed over a disposable SSH. Dev has no maintenance mode, so a dropped connection can't strand a site here — but it can still kill the run part-way through `migrate` or `collectstatic`. The script also now reports a real exit status, which it previously did not.

## Testing

- `home/tests.py` had never contained a test. Five now cover where the enquiry goes, what Reply hits, that the backend default doesn't overwrite an explicit `reply_to`, and the honeypot and link-limit paths that must send nothing.
- `python manage.py test home utils chatbot` — 86 tests, all pass
- both scripts pass `bash -n`; the detach mechanism itself was verified against the real server in #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)