### PR TITLE
Let the contact form honeypot fake success instead of announcing the catch

### DIFF
--- a/home/forms.py
+++ b/home/forms.py
@@ -13,17 +13,16 @@ class ContactForm(forms.Form):
     message = forms.CharField(widget=forms.Textarea)
     captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox())
 
-    # Honeypot field - hidden from humans, bots will fill it in
+    # Honeypot field - hidden from humans, bots will fill it in.
+    # Deliberately left un-cleaned: info_view reads this value to decide whether
+    # to fake success, so the form must pass it through as submitted. It used to
+    # have a clean_website() that raised ValidationError, which defeated that
+    # twice over — the form came back invalid, so the view never got to look,
+    # and the bot was told "Spam detected." instead of being quietly dropped.
     website = forms.CharField(
         required=False,
         widget=forms.HiddenInput(attrs={'tabindex': '-1', 'autocomplete': 'off'}),
     )
-
-    def clean_website(self):
-        """Reject submissions where the honeypot field is filled in."""
-        if self.cleaned_data.get('website'):
-            raise ValidationError('Spam detected.')
-        return ''
 
     def clean_message(self):
         """Basic spam content checks."""

--- a/home/tests.py
+++ b/home/tests.py
@@ -10,6 +10,8 @@ from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
 
+from home.forms import ContactForm
+
 
 class ContactFormEmailTests(TestCase):
     def setUp(self):
@@ -57,6 +59,27 @@ class ContactFormEmailTests(TestCase):
 
         self.assertEqual(len(mail.outbox), 0)
         self.assertEqual(response.status_code, 200)
+
+    def test_a_honeypot_submission_is_told_it_succeeded(self):
+        """The point of a honeypot: the bot must not learn it was caught, or
+        whoever runs it just stops filling the field in."""
+        response = self.submit(website='http://spam.example.com')
+
+        self.assertTrue(response.context['success'])
+        self.assertNotContains(response, 'Spam detected')
+
+    def test_the_honeypot_value_survives_cleaning(self):
+        """info_view is the only thing that acts on the honeypot, so the form
+        has to hand it the value as submitted. A clean_website() that blanked or
+        rejected it would send the bot's mail, or show it an error."""
+        form = ContactForm(data={
+            'name': 'Bot', 'email': 'bot@example.com', 'subject': 'x',
+            'message': 'x', 'captcha': 'PASSED',
+            'website': 'http://spam.example.com',
+        })
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data['website'], 'http://spam.example.com')
 
     def test_a_message_full_of_links_sends_nothing(self):
         self.submit(message='http://a.example http://b.example http://c.example')


### PR DESCRIPTION
Follow-up to #218, where I flagged this but left it alone.

## The problem

The honeypot was handled in two places that disagreed, and the form's half won.

`info_view` has the intended design — a filled honeypot returns success without sending anything, so whoever runs the bot can't tell the field is a trap. `ContactForm.clean_website` defeated it twice over:

1. it raised `ValidationError`, so `form.is_valid()` was already `False` and the view's branch was unreachable
2. it returned `''`, so even without the raise, the view's `if form.cleaned_data.get('website')` would never have fired — and the bot's mail would have been **sent**

The visible effect: a bot got back "Spam detected." That's the one thing a honeypot must not do. It names the field as the trap, and the next run just leaves it blank.

## The fix

Removed `clean_website`, making `info_view` the sole handler. The field is now deliberately left un-cleaned, with a comment saying why — blanking it in the form is a silent way to start mailing every spam submission.

No behaviour change for legitimate submissions, and none for what actually reached the inbox: nothing was sent before and nothing is sent now. What changes is what the bot is told.

## Testing

Two new tests, both of which **fail against the old code** (verified by restoring `clean_website` and re-running):

- `test_a_honeypot_submission_is_told_it_succeeded` — bot sees success, not "Spam detected"
- `test_the_honeypot_value_survives_cleaning` — the form hands the view the value as submitted

`python manage.py test home utils chatbot` — 88 tests, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)