### PR TITLE
Remove the commented-out HPP_FORM lines from the settings files

### DIFF
--- a/config/base_settings.py
+++ b/config/base_settings.py
@@ -471,7 +471,6 @@ CART_SESSION_ID = 'cart'
 # BOIPA_PASSWORD='qWGEJQQAkhROSTGpwS5O'
 # BOIPA_TOKEN_URL="https://apiuat.test.boipapaymentgateway.com/token"
 # BOIPA_PAYMENT_URL='https://apiuat.test.boipapaymentgateway.com/payments'
-# HPP_FORM='https://cashierui-apiuat.test.boipapaymentgateway.com/'
 # NGROK ='https://tcsp-morganmck.eu.pythonanywhere.com/'
 
 # How many records can you upload

--- a/config/development_settings.py
+++ b/config/development_settings.py
@@ -28,7 +28,6 @@ NGROK                  = config('NGROK', default='http://localhost:4040').rstrip
 # Old BOIPA variables (deprecated but kept for reference)
 # BOIPA_PASSWORD     = config('BOIPA_PASSWORD', default='')
 # BOIPA_TOKEN_URL    = config('BOIPA_TOKEN_URL', default='')
-# HPP_FORM           = config('HPP_FORM', default='')
 # BRAND_ID           = config('BRAND_ID', default='')
 # BOIPA_PAYMENT_URL  = config('BOIPA_PAYMENT_URL', default='')
 

--- a/config/production_settings.py
+++ b/config/production_settings.py
@@ -35,7 +35,6 @@ NGROK                  = config('NGROK', default='https://www.tcsp.ie').rstrip('
 # BOIPA_MERCHANT_ID  = config('BOIPA_MERCHANT_ID')
 # BOIPA_PASSWORD     = config('BOIPA_PASSWORD')
 # BOIPA_TOKEN_URL    = config('BOIPA_TOKEN_URL')
-# HPP_FORM           = config('HPP_FORM')
 # NGROK              = config('NGROK', default='http://localhost:4040').rstrip('/')
 # BRAND_ID           = config('BRAND_ID')
 # BOIPA_PAYMENT_URL  = config('BOIPA_PAYMENT_URL')


### PR DESCRIPTION
Deletes three commented-out `HPP_FORM` lines, one each from `base_settings.py`, `development_settings.py` and `production_settings.py`.

`HPP_FORM` was the hosted payment page URL under the old BOIPA API. It was superseded by `BOIPA_HPP_LINKS_URL` when the integration moved to OAuth2, and nothing has read it since — `boipa/payment_functions.py` builds the hosted page from `BOIPA_HPP_LINKS_URL`. I checked before removing: the only references left in the repo were these three commented lines plus mentions in `docs/`.

All three were already commented out, so **this changes no behaviour**. They're going because the setting no longer exists anywhere to be uncommented back into — the last live definition was in `config/local_settings.py`, which is gitignored and has been cleaned up separately.

## Why bother

The value these lines carried was a stale live-gateway URL, and a comment that looks like configuration is exactly how a stale endpoint gets copied back into a real `.env`.

That isn't hypothetical. The dev server's `.env` had its BOIPA block headed `# ===== NEW BOIPA (Sandbox) API =====` while every value under it pointed at the live gateway — same `apis.boipagateway.com` host, same merchant account as production, which has 2,082 real EUR transactions through it. Dev has since been moved onto the actual sandbox (`apis.sandbox.globalpay.com`), verified by a checkout that now routes to `pay.sandbox.realexpayments.com`.

## Scope

Only the `HPP_FORM` lines. The surrounding blocks of deprecated BOIPA variables are left as they are.

Separately worth a look, not touched here: `config/base_settings.py:471` has a plaintext `BOIPA_PASSWORD` in its commented block. It's for the retired UAT gateway and it's commented, but it is a credential in tracked code and it's in the history regardless.

## Testing

`python manage.py test` — 166 tests. The six failures (four BOIPA integration, two prorated pricing) are identical on `main` and untouched here. All three settings modules compile, and `config.local_settings` loads with `BOIPA_HPP_LINKS_URL` resolving correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)